### PR TITLE
feat: export가 하나일땐 export default로 내보내야 하는 eslint 규칙 삭제

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,5 +72,6 @@ module.exports = {
     'import/extensions': ['off'],
     'import/no-extraneous-dependencies': ['off'],
     'no-param-reassign': ['error', { props: false }],
+    'import/prefer-default-export': 'off',
   },
 };


### PR DESCRIPTION
- emotion Styled 네이밍 컨벤션에 적합하지 않습니다