### PR TITLE
fix: 프론트 작업 도중 tsconfig이 자동으로 수정되던 문제 수정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,11 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "esModuleInterop": true,
+    "allowJs": false,
+    "skipLibCheck": false,
+    "forceConsistentCasingInFileNames": false,
+    "noEmit": false,
+    "jsx": "preserve"
   },
   "exclude": [
     "node_modules",
@@ -35,5 +39,6 @@
     "store",
     "styles",
     "dist"
-  ]
+  ],
+  "include": []
 }


### PR DESCRIPTION
next.js에서 root에 tsconfig이 있을시에 tsconfig에 next의 ts 관련 설정을 자동 삽입하던 문제를 수정했습니다.
예외적으로 compilerOptions.jsx 옵션은 디폴트 값이 undefined 인데 해당 값은 json에서 취급하지 않아 미리 입력해둘 수 없었는데,  백엔드 개발에 영향을 미치지 않는 옵션이라 생각하여 next에서 자동으로 설정하는 값인 "preserve"로 냅두었습니다. 해당 옵션으로 문제 발생 시 말씀해주세요