### PR TITLE
수정: next 의 tsconfig 간섭 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ lerna-debug.log*
 *.sublime-workspace
 
 # IDE - VSCode
+.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.server.json",
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "components", "locales", "pages", "public", "redux"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,25 @@
     "downlevelIteration": true,
     "noImplicitAny": true,
     "strict": true,
-  }
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "allowJs": false,
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "noImplicitAny": true,
+    "strict": true,
+  }
+}


### PR DESCRIPTION
##### 더 이상 next 가 수정하는 tsconfig 다시 수동 rollback 시켜 주지 않아도 됩니다.
##### 백엔드는 이제 tsconfig.json 을 참조해서 빌드를 수행하지 않습니다.