### PR TITLE
refactor: 반복되는 액션 타입 생성 과정 리팩터링

### DIFF
--- a/lib/makeActions.js
+++ b/lib/makeActions.js
@@ -1,0 +1,35 @@
+/**
+ * @example
+    import makeActions from '~/lib/makeActions';
+
+    const moduleName = 'common';
+    const actionNames = ['LOGIN', 'LOGOUT'];
+    const actions = makeActions(moduleName, actionNames);
+
+    export default actions;
+ *
+ * @example <caption>Example usage in reducer</caption>
+    import userActions from '~/redux/actions/common/user';
+
+    const { LOGIN, LOGOUT } = userActions;
+    
+    switch (action.type) {
+      case LOGIN.REQUEST:
+        ...
+      case LOGIN.SUCCESS:
+        ...
+      case LOGIN.FAILURE:
+        ...
+    }
+ */
+
+export default function makeActions(moduleName, actionNames) {
+  return actionNames.reduce((acc, currAction) => {
+    acc[currAction] = {
+      REQUEST: `${moduleName}/${currAction}_REQUEST`,
+      SUCCESS: `${moduleName}/${currAction}_SUCCESS`,
+      FAILURE: `${moduleName}/${currAction}_FAILURE`,
+    };
+    return acc;
+  }, {});
+}

--- a/lib/makeActions.js
+++ b/lib/makeActions.js
@@ -1,26 +1,6 @@
 /**
  * @example
-    import makeActions from '~/lib/makeActions';
-
-    const moduleName = 'common';
-    const actionNames = ['LOGIN', 'LOGOUT'];
-    const actions = makeActions(moduleName, actionNames);
-
-    export default actions;
- *
- * @example <caption>Example usage in reducer</caption>
-    import userActions from '~/redux/actions/common/user';
-
-    const { LOGIN, LOGOUT } = userActions;
-    
-    switch (action.type) {
-      case LOGIN.REQUEST:
-        ...
-      case LOGIN.SUCCESS:
-        ...
-      case LOGIN.FAILURE:
-        ...
-    }
+ * https://github.com/bear-bear-bear/mogakco/pull/63
  */
 
 export default function makeActions(moduleName, actionNames) {

--- a/redux/actions/common/user.js
+++ b/redux/actions/common/user.js
@@ -1,7 +1,7 @@
-export const LOGIN_REQUEST = 'common/LOGIN_REQUEST';
-export const LOGIN_SUCCESS = 'common/LOGIN_SUCCESS';
-export const LOGIN_FAILURE = 'common/LOGIN_FAILURE';
+import makeActions from '~/lib/makeActions';
 
-export const LOGOUT_REQUEST = 'common/LOGOUT_REQUEST';
-export const LOGOUT_SUCCESS = 'common/LOGOUT_SUCCESS';
-export const LOGOUT_FAILURE = 'common/LOGOUT_FAILURE';
+const moduleName = 'common';
+const actionNames = ['LOGIN', 'LOGOUT'];
+const actions = makeActions(moduleName, actionNames);
+
+export default actions;

--- a/redux/reducers/common/user.js
+++ b/redux/reducers/common/user.js
@@ -1,14 +1,9 @@
 import produce from 'immer';
 import { handleActions } from 'redux-actions';
 
-import {
-  LOGIN_REQUEST,
-  LOGIN_SUCCESS,
-  LOGIN_FAILURE,
-  LOGOUT_REQUEST,
-  LOGOUT_SUCCESS,
-  LOGOUT_FAILURE,
-} from '~/redux/actions/common/user';
+import userActions from '~/redux/actions/common/user';
+
+const { LOGIN, LOGOUT } = userActions;
 
 const initialState = {
   me: null,
@@ -30,38 +25,38 @@ const dummyUser = {
 
 const user = handleActions(
   {
-    [LOGIN_REQUEST]: (state) =>
+    [LOGIN.REQUEST]: (state) =>
       produce(state, (draft) => {
         draft.logInLoading = true;
         draft.logInDone = false;
         draft.logInError = null;
       }),
     // eslint-disable-next-line no-unused-vars
-    [LOGIN_SUCCESS]: (state, { payload: me }) =>
+    [LOGIN.SUCCESS]: (state, { payload: me }) =>
       produce(state, (draft) => {
         draft.logInLoading = false;
         draft.logInDone = true;
         // draft.me = me;
         draft.me = dummyUser;
       }),
-    [LOGIN_FAILURE]: (state, { payload: error }) =>
+    [LOGIN.FAILURE]: (state, { payload: error }) =>
       produce(state, (draft) => {
         draft.logInLoading = false;
         draft.logInError = error;
       }),
-    [LOGOUT_REQUEST]: (state) =>
+    [LOGOUT.REQUEST]: (state) =>
       produce(state, (draft) => {
         draft.logOutLoading = true;
         draft.logOutDone = false;
         draft.logOutError = null;
       }),
-    [LOGOUT_SUCCESS]: (state) =>
+    [LOGOUT.SUCCESS]: (state) =>
       produce(state, (draft) => {
         draft.logOutLoading = false;
         draft.logOutDone = true;
         draft.me = null;
       }),
-    [LOGOUT_FAILURE]: (state, { payload: error }) =>
+    [LOGOUT.FAILURE]: (state, { payload: error }) =>
       produce(state, (draft) => {
         draft.logOutLoading = false;
         draft.logOutError = error;


### PR DESCRIPTION
추가된 함수 lib/`makeActions`는 module name과 action name 배열을 인자로 받아 각 액션 네임으로 된 프로퍼티에 REQUEST, SUCCESS, FAILURE 에 대한 액션 타입을 가지는 객체를 반환합니다.
``` js
const moduleName = 'common';
const actionNames = ['LOGIN', 'LOGOUT'];
const actions = makeActions(moduleName, actionNames);

console.log(actions);
// { 
//   LOGIN:  { 
//     REQUEST: 'common/LOGIN_REQUEST', 
//     SUCCESS: 'common/LOGIN_SUCCESS', 
//     FAILURE: 'common/LOGIN_FAILURE',
//   }, 
//   LOGOUT:  { 
//     REQUEST: 'common/LOGOUT_REQUEST', 
//     SUCCESS: 'common/LOGOUT_SUCCESS', 
//     FAILURE: 'common/LOGOUT_FAILURE',
//   },
// } 
```

위 예시의 `actions` 객체는 다음과 같이 사용할 수 있습니다.
``` js
const { LOGIN, LOGOUT } = actions;

const reducer = (state = initialState, action) => {
  switch (action.type) {
    case LOGIN.REQUEST:
      ...
    case LOGIN.SUCCESS:
      ...
    case LOGIN.FAILURE:
      ...
  }
}
```

----------------------------------
makeActions로 action들을 생성하여 export하는 방법에는 2가지가 있는데, 각각 장단점이 존재합니다.
저는 1번처럼 사용하는게 낫다고 생각하는데, 팀원분들의 의견도 듣고싶습니다.

**사용 예시 1번**입니다.
액션 정의 시에 `actionNames` 안에 이름 한 번만 넣어주면 된다는 장점이 있습니다.
다른 파일에서 import 한 후 해당 모듈을 한번 더 구조분해 해주어야 한다는 번거로움이 있습니다.
``` js
// actions/user.js
import makeActions from '~/lib/makeActions';

const moduleName = 'common';
const actionNames = ['LOGIN', 'LOGOUT'];
const actions = makeActions(moduleName, actionNames);

export default actions;

// reducers/user.js
import userActions from '~/redux/actions/common/user';

const { LOGIN, LOGOUT } = userActions;
```

**사용 예시 2번**입니다.
액션 정의 시에 `actionNames`안에 이름을 추가하면서 makeActions 라인과 export 라인에도 액션 이름을 반복 추가해야 한다는 번거로움이 있습니다.
다른 파일에서 import 할때 구조분해를 동시에 할 수 있는 장점이 있습니다.
``` js
// actions/user.js
import makeActions from '~/lib/makeActions';

const moduleName = 'common';
const actionNames = ['LOGIN', 'LOGOUT'];
const { LOGIN, LOGOUT } = makeActions(moduleName, actionNames);

export { LOGIN, LOGOUT };

// reducers/user.js
import { LOGIN, LOGOUT } from '~/redux/actions/common/user';
```

어떤게 낫다고 생각하시나요?