### PR TITLE
사용자 시딩 추가

### DIFF
--- a/nest/.eslintrc.json
+++ b/nest/.eslintrc.json
@@ -27,7 +27,8 @@
     "@typescript-eslint/no-shadow": "warn",
     "no-unused-vars": "error",
     "max-classes-per-file": ["off"],
-    "import/no-cycle": "off"
+    "import/no-cycle": "off",
+    "no-param-reassign": "warn"
   },
   "ignorePatterns": ["dist", "node_modules"]
 }

--- a/nest/factory/helper/utils.ts
+++ b/nest/factory/helper/utils.ts
@@ -1,0 +1,3 @@
+export const getRandomCount = (count: number) => Math.floor(Math.random() * count);
+
+export default {};

--- a/nest/factory/users-field.factory.ts
+++ b/nest/factory/users-field.factory.ts
@@ -1,7 +1,7 @@
 import { define } from 'typeorm-seeding';
 import UserFieldEntity from '../models/entities/user-field.entity';
 
-const fieldData = [
+export const fieldData = [
   '프론트엔드',
   '백엔드',
   '풀스택',
@@ -18,8 +18,7 @@ const fieldData = [
   '리눅스',
 ];
 
-const fieldDataLength = fieldData.length;
-export default fieldDataLength;
+export const fieldDataLength = fieldData.length;
 
 define(UserFieldEntity, () => {
   const field = new UserFieldEntity();

--- a/nest/factory/users-job.factory.ts
+++ b/nest/factory/users-job.factory.ts
@@ -1,7 +1,7 @@
 import { define } from 'typeorm-seeding';
 import UserJobEntity from '../models/entities/users-job.entity';
 
-const jobData = [
+export const jobData = [
   '학생',
   '웹 개발자',
   '서버 개발자',
@@ -13,8 +13,7 @@ const jobData = [
   '기타',
 ];
 
-const jobDataLength = jobData.length;
-export default jobDataLength;
+export const jobDataLength = jobData.length;
 
 define(UserJobEntity, () => {
   const job = new UserJobEntity();

--- a/nest/factory/users.factory.ts
+++ b/nest/factory/users.factory.ts
@@ -1,21 +1,12 @@
 import Faker from 'faker';
 import { define } from 'typeorm-seeding';
-import { fieldDataLength } from './users-field.factory';
 import UserEntity from '../models/entities/user.entity';
-import { getRandomCount } from './helper/utils';
 
 define(UserEntity, (faker: typeof Faker) => {
-  const fieldIndexArray = Array(fieldDataLength).map((_, index) => String(index));
-  const skillCount = getRandomCount(fieldDataLength);
-
+  faker.locale = 'ko';
   const user = new UserEntity();
-  user.username = faker.name.lastName();
-  user.createdAt = new Date();
+  user.username = faker.name.lastName() + faker.name.firstName();
   user.email = faker.internet.email();
-  user.updatedAt = new Date();
-  user.skills = Array(skillCount)
-    .fill(0)
-    .map(() => fieldIndexArray[getRandomCount(fieldDataLength)]);
-
+  user.password = 'junjae';
   return user;
 });

--- a/nest/factory/users.factory.ts
+++ b/nest/factory/users.factory.ts
@@ -6,7 +6,8 @@ define(UserEntity, (faker: typeof Faker) => {
   faker.locale = 'ko';
   const user = new UserEntity();
   user.username = faker.name.lastName() + faker.name.firstName();
-  user.email = user.username + faker.internet.email();
+  faker.locale = 'en';
+  user.email = faker.name.lastName() + faker.internet.email();
   user.password = 'junjae';
   return user;
 });

--- a/nest/factory/users.factory.ts
+++ b/nest/factory/users.factory.ts
@@ -1,0 +1,21 @@
+import Faker from 'faker';
+import { define } from 'typeorm-seeding';
+import { fieldDataLength } from './users-field.factory';
+import UserEntity from '../models/entities/user.entity';
+import { getRandomCount } from './helper/utils';
+
+define(UserEntity, (faker: typeof Faker) => {
+  const fieldIndexArray = Array(fieldDataLength).map((_, index) => String(index));
+  const skillCount = getRandomCount(fieldDataLength);
+
+  const user = new UserEntity();
+  user.username = faker.name.lastName();
+  user.createdAt = new Date();
+  user.email = faker.internet.email();
+  user.updatedAt = new Date();
+  user.skills = Array(skillCount)
+    .fill(0)
+    .map(() => fieldIndexArray[getRandomCount(fieldDataLength)]);
+
+  return user;
+});

--- a/nest/factory/users.factory.ts
+++ b/nest/factory/users.factory.ts
@@ -6,7 +6,7 @@ define(UserEntity, (faker: typeof Faker) => {
   faker.locale = 'ko';
   const user = new UserEntity();
   user.username = faker.name.lastName() + faker.name.firstName();
-  user.email = faker.internet.email();
+  user.email = user.username + faker.internet.email();
   user.password = 'junjae';
   return user;
 });

--- a/nest/models/entities/user.entity.ts
+++ b/nest/models/entities/user.entity.ts
@@ -3,6 +3,14 @@ import { Exclude } from 'class-transformer';
 import { BaseEntitySoftDelete } from './helper/abstract';
 import UserJobEntity from './users-job.entity';
 
+interface IUserProps {
+  username: string;
+  email: string;
+  password: string;
+  skills: string[];
+  job: UserJobEntity | null;
+}
+
 @Entity({
   name: 'users',
 })
@@ -26,7 +34,16 @@ class UserEntity extends BaseEntitySoftDelete {
   /* relation */
   @ManyToOne(() => UserJobEntity, job => job.user)
   @JoinColumn({ name: 'job_id' })
-  job?: UserJobEntity;
+  job?: UserJobEntity | null;
+
+  constructor({ email, job, password, skills, username }: IUserProps) {
+    super();
+    this.username = username;
+    this.email = email;
+    this.password = password;
+    this.skills = skills;
+    this.job = job;
+  }
 }
 
 export default UserEntity;

--- a/nest/models/entities/user.entity.ts
+++ b/nest/models/entities/user.entity.ts
@@ -3,14 +3,6 @@ import { Exclude } from 'class-transformer';
 import { BaseEntitySoftDelete } from './helper/abstract';
 import UserJobEntity from './users-job.entity';
 
-interface IUserProps {
-  username: string;
-  email: string;
-  password: string;
-  skills: string[];
-  job: UserJobEntity | null;
-}
-
 @Entity({
   name: 'users',
 })
@@ -25,7 +17,7 @@ class UserEntity extends BaseEntitySoftDelete {
   password!: string;
 
   @Column({ nullable: false, type: 'simple-array' })
-  skills!: number[];
+  skills!: number[] | null;
 
   @Column({ nullable: true, name: 'refresh_token' })
   @Exclude()
@@ -35,15 +27,6 @@ class UserEntity extends BaseEntitySoftDelete {
   @ManyToOne(() => UserJobEntity, job => job.user)
   @JoinColumn({ name: 'job_id' })
   job?: UserJobEntity | null;
-
-  constructor({ email, job, password, skills, username }: IUserProps) {
-    super();
-    this.username = username;
-    this.email = email;
-    this.password = password;
-    this.skills = skills;
-    this.job = job;
-  }
 }
 
 export default UserEntity;

--- a/nest/models/repositories/user.repository.ts
+++ b/nest/models/repositories/user.repository.ts
@@ -6,14 +6,19 @@ import createUserDTO from '../dto/create-user.dto';
 
 @EntityRepository(UserEntity)
 class UserRepository extends Repository<UserEntity> {
-  async createUserOne(user: createUserDTO): Promise<UserEntity> {
-    const job = await UserJobEntity.findOne(user.job);
+  async createUserOne({
+    username,
+    password,
+    email,
+    job,
+    skills,
+  }: createUserDTO): Promise<UserEntity> {
     const newUser = new UserEntity();
-    newUser.password = user.password;
-    newUser.username = user.username;
-    newUser.email = user.email;
-    newUser.skills = user.skills;
-    newUser.job = job;
+    newUser.username = username;
+    newUser.password = password;
+    newUser.email = email;
+    newUser.job = job as unknown as UserJobEntity;
+    newUser.skills = skills;
 
     await this.save(newUser);
     return newUser;

--- a/nest/package.json
+++ b/nest/package.json
@@ -23,7 +23,7 @@
     "migrate:revert": "npm run typeorm migration:revert",
     "migrate": "npm run typeorm migration:run",
     "seed:config": "ts-node ./node_modules/typeorm-seeding/dist/cli.js config",
-    "seed:run": "ts-node ./node_modules/typeorm-seeding/dist/cli.js seed",
+    "seed:run": "npm run schema:drop && npm run schema:sync && ts-node ./node_modules/typeorm-seeding/dist/cli.js seed",
     "schema:drop": "npm run typeorm schema:drop",
     "schema:sync": "npm run typeorm schema:sync"
   },

--- a/nest/seeders/user-props.ts
+++ b/nest/seeders/user-props.ts
@@ -1,20 +1,35 @@
 import { Factory, Seeder } from 'typeorm-seeding';
+import makeHash from '../lib/makeHash';
 import UserJobEntity from '../models/entities/users-job.entity';
 import { jobDataLength } from '../factory/users-job.factory';
 import { fieldDataLength } from '../factory/users-field.factory';
 import UserFieldEntity from '../models/entities/user-field.entity';
 import UserEntity from '../models/entities/user.entity';
 
+
 export default class CreateUserJobs implements Seeder {
   async run(factory: Factory) {
     await factory(UserJobEntity)().createMany(jobDataLength);
     await factory(UserFieldEntity)().createMany(fieldDataLength);
     await factory(UserEntity)()
-      .map(async (user: UserEntity): Promise<any> => {
+      .map(async ({ username, email, password: plain }: UserEntity): Promise<any> => {
+        const password = await makeHash(plain);
         const jobList = await UserJobEntity.find();
+        const fieldList = await UserFieldEntity.find();
+        const fieldIndexArray = fieldList.map(({ id }) => id);
         const rand = Math.floor(Math.random() * jobList.length);
         const returnUser = new UserEntity();
-        return user;
+        returnUser.username = username;
+        returnUser.password = password;
+        returnUser.email = email;
+        returnUser.skills = [
+          // TODO: 코드 보완 예정
+          fieldIndexArray[1],
+          fieldIndexArray[3],
+          fieldIndexArray[4],
+        ];
+        returnUser.job = jobList[rand];
+        return returnUser;
       })
       .createMany(30);
   }

--- a/nest/seeders/user-props.ts
+++ b/nest/seeders/user-props.ts
@@ -1,12 +1,21 @@
 import { Factory, Seeder } from 'typeorm-seeding';
 import UserJobEntity from '../models/entities/users-job.entity';
-import jobDataLength from '../factory/users-job.factory';
-import fieldDataLength from '../factory/users-field.factory';
+import { jobDataLength } from '../factory/users-job.factory';
+import { fieldDataLength } from '../factory/users-field.factory';
 import UserFieldEntity from '../models/entities/user-field.entity';
+import UserEntity from '../models/entities/user.entity';
 
 export default class CreateUserJobs implements Seeder {
   async run(factory: Factory) {
     await factory(UserJobEntity)().createMany(jobDataLength);
     await factory(UserFieldEntity)().createMany(fieldDataLength);
+    await factory(UserEntity)()
+      .map(async (user: UserEntity): Promise<any> => {
+        const jobList = await UserJobEntity.find();
+        const rand = Math.floor(Math.random() * jobList.length);
+        const returnUser = new UserEntity();
+        return user;
+      })
+      .createMany(30);
   }
 }

--- a/nest/seeders/user-props.ts
+++ b/nest/seeders/user-props.ts
@@ -11,7 +11,7 @@ export default class CreateUserJobs implements Seeder {
     await factory(UserJobEntity)().createMany(jobDataLength);
     await factory(UserFieldEntity)().createMany(fieldDataLength);
     await factory(UserEntity)()
-      .map(async ({ username, email, password: plain }: UserEntity): Promise<any> => {
+      .map(async ({ username, email, password: plain }: UserEntity): Promise<UserEntity> => {
         const password = await makeHash(plain);
         const jobList = await UserJobEntity.find();
         const fieldList = await UserFieldEntity.find();

--- a/nest/seeders/user-props.ts
+++ b/nest/seeders/user-props.ts
@@ -6,7 +6,6 @@ import { fieldDataLength } from '../factory/users-field.factory';
 import UserFieldEntity from '../models/entities/user-field.entity';
 import UserEntity from '../models/entities/user.entity';
 
-
 export default class CreateUserJobs implements Seeder {
   async run(factory: Factory) {
     await factory(UserJobEntity)().createMany(jobDataLength);

--- a/nest/seeders/user-props.ts
+++ b/nest/seeders/user-props.ts
@@ -1,15 +1,24 @@
 import { Factory, Seeder } from 'typeorm-seeding';
+import { getCustomRepository } from 'typeorm';
 import makeHash from '../lib/makeHash';
 import UserJobEntity from '../models/entities/users-job.entity';
 import { jobDataLength } from '../factory/users-job.factory';
 import { fieldDataLength } from '../factory/users-field.factory';
 import UserFieldEntity from '../models/entities/user-field.entity';
 import UserEntity from '../models/entities/user.entity';
+import UserRepository from '../models/repositories/user.repository';
 
 export default class CreateUserJobs implements Seeder {
   async run(factory: Factory) {
     await factory(UserJobEntity)().createMany(jobDataLength);
     await factory(UserFieldEntity)().createMany(fieldDataLength);
+    await getCustomRepository(UserRepository).createUserOne({
+      username: 'mogauser',
+      password: await makeHash('mogapass'),
+      email: process.env.EMAIL_ADMIN as string,
+      skills: [1, 2, 3],
+      job: 1,
+    });
     await factory(UserEntity)()
       .map(async ({ username, email, password: plain }: UserEntity): Promise<UserEntity> => {
         const password = await makeHash(plain);


### PR DESCRIPTION
## Feature
* npm run seed:run 명령어가 schema:drop, schema:sync 모두 같이 수행합니다.
* 사용자 시드가 추가되었습니다. npm run seed:run 부탁드립니다.
* 사용자에 시드가 돌면서, skills 와 job 연관 데이터가 생성됩니다. ( skills 보완 예정 )
* 객체 재정의 방지에 대한 eslint 옵션을 warn 으로 교체하였습니다.
* 테스트용 유저 시딩 추가
* * *
![image](https://user-images.githubusercontent.com/50310464/120737444-08fc1000-c529-11eb-9b20-b2cbbb8fc0b0.png)
