### PR TITLE
TEST: 백엔드 로그인 테스트 작성

### DIFF
--- a/nest/modules/app.module.ts
+++ b/nest/modules/app.module.ts
@@ -28,6 +28,7 @@ import MailModule from './mail.module';
         JWT_ACCESS_TOKEN_EXPIRATION_TIME: Joi.number().required(),
         JWT_REFRESH_TOKEN_SECRET: Joi.string().required(),
         JWT_REFRESH_TOKEN_EXPIRATION_TIME: Joi.number().required(),
+        TYPEORM_LOGGING: Joi.boolean().required(),
       }),
     }),
     TypeOrmModule.forRoot({
@@ -38,7 +39,7 @@ import MailModule from './mail.module';
       password: process.env.DATABASE_PASSWORD as string,
       database: process.env.DATABASE_NAME as string,
       synchronize: process.env.NODE_ENV === 'development',
-      logging: process.env.NODE_ENV === 'development',
+      logging: Boolean(process.env.TYPEORM_LOGGING),
       migrationsTableName: 'migrations',
       migrations: ['migrations/*.ts'],
       cli: { migrationsDir: 'migration' },

--- a/nest/test/e2e/auth/user-login.e2e-spec.ts
+++ b/nest/test/e2e/auth/user-login.e2e-spec.ts
@@ -66,7 +66,6 @@ describe('사용자 로그인 테스트', () => {
         }));
       accessToken = response.accessToken;
       refreshToken = response.body.refreshToken;
-      console.log({ refreshToken });
       evalResponseBodyMessage(response.body, 200, '로그인에 성공하였습니다!');
     });
 

--- a/nest/test/e2e/auth/user-login.e2e-spec.ts
+++ b/nest/test/e2e/auth/user-login.e2e-spec.ts
@@ -1,0 +1,83 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import AppModule from '@modules/app.module';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+import { evalResponseBodyMessage, evalToStrictEqualBodyMessage } from '@test/e2e/helper/support';
+
+describe('사용자 로그인 테스트', () => {
+  let app: INestApplication;
+  let loginForm: { email: string; password: string };
+  let accessToken: string;
+  let refreshToken: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    loginForm = {
+      email: 'mogakco35@gmail.com',
+      password: 'mogapass',
+    };
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.use(cookieParser());
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /api/auth/login - 사용자 로그인', () => {
+    it('로그인 시도에 잘못된 요청 양식을 보낼 경우 실패한다.', async () => {
+      const wrongLoginForm = {
+        email: loginForm.email,
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send(wrongLoginForm)
+        .then(({ body: res }) => {
+          evalToStrictEqualBodyMessage(res, {
+            statusCode: 400,
+            message: ['password must be a string'],
+            error: 'Bad Request',
+          });
+        });
+    });
+
+    it('로그인에 성공하고 토큰 값을 반환받는다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send(loginForm)
+        .then(res => ({
+          accessToken: res.headers['set-cookie'][0].split(';')[0].slice(12),
+          body: res.body,
+        }));
+      accessToken = response.accessToken;
+      refreshToken = response.body.refreshToken;
+      console.log({ accessToken, refreshToken });
+      evalResponseBodyMessage(response.body, 200, '로그인에 성공하였습니다!');
+    });
+
+    it('로그인 한 유저는 회원가입을 수행할 수 없다.', async () => {
+      await request(app.getHttpServer())
+        .post('/api/auth')
+        .set('Cookie', [`accessToken=${accessToken}`])
+        .then(({ body: res }) =>
+          evalResponseBodyMessage(res, 401, '로그인 상태에서 접근할 수 없습니다.'),
+        );
+    });
+  });
+});

--- a/nest/test/e2e/auth/user-login.e2e-spec.ts
+++ b/nest/test/e2e/auth/user-login.e2e-spec.ts
@@ -131,4 +131,21 @@ describe('사용자 로그인 테스트', () => {
         });
     });
   });
+
+  describe('POST /api/auth/logout - 유저 로그아웃', () => {
+    it('로그인 상태가 아니라면 401이 반환된다.', async () => {
+      await request(app.getHttpServer())
+        .post('/api/auth/logout')
+        .then(({ body: res }) => evalResponseBodyMessage(res, 401, 'Unauthorized'));
+    });
+
+    it('로그아웃을 정상적으로 수행한다.', async () => {
+      await request(app.getHttpServer())
+        .post('/api/auth/logout')
+        .set('Authorization', `bearer ${refreshToken}`)
+        .then(({ body: res }) =>
+          evalResponseBodyMessage(res, 200, 'mogauser 유저가 로그아웃 되었습니다.'),
+        );
+    });
+  });
 });

--- a/nest/test/e2e/helper/support.ts
+++ b/nest/test/e2e/helper/support.ts
@@ -20,3 +20,10 @@ export const evalToContainBodyMessage = (
   expect(response.statusCode).toBe(expectStatusCode);
   expect(response.message).toContain(expectMessage);
 };
+
+export const evalToStrictEqualBodyMessage = (
+  response: ResponseBodyProps & { error: string },
+  strictEqual: any,
+) => {
+  expect(response).toStrictEqual(strictEqual);
+};


### PR DESCRIPTION
## Test List
* /api/auth/login 로그인 테스트
  - [x] 로그인 시도에 잘못된 요청 양식을 보낼 경우 실패한다.
  - [x] 로그인에 성공하고 토큰 값을 받는다.
  - [x] 로그인 한 유저는 회원가입을 수행할 수 없다.
* /api/auth/test 로그인 상태 여부 테스트 ( 테스트에서만 쓰이는 Api )
  - [x] 로그인한 상태면, accessToken, 간단한 유저 정보가 반환된다.
  - [x] 10분이 지나면 401이 반환된다.
* /api/auth/refresh-token 새로운 accessToken 발급
  - [x] refreshToken 값이 검증되면 accessToken, 유저 정보 객체를 발급한다.
  - [x] refreshToken 이 만료되거나 존재하지 않으면 401이 반환된다.
  - [x] refreshToken 발급 후, /api/auth/test 가 정상적으로 응답된다.
* /api/auth/logout 로그아웃 테스트
  - [x] 로그인 상태가 아니라면 401이 반환된다.
  - [x] 로그아웃을 수행한다.
* * *
![test_image](https://user-images.githubusercontent.com/50310464/121517501-68c35100-ca2a-11eb-8f1d-4d45db91fddc.png)
