### PR TITLE
FEATURE: 프런트엔드 Path Alias 수정 및 추가

### DIFF
--- a/next/.babelrc
+++ b/next/.babelrc
@@ -14,7 +14,14 @@
     "@emotion/babel-plugin",
     ["module-resolver", {
       "~": "./",
-      "assets": "./public/assets"
+      "@assets": "./public/assets",
+      "@components": "./components",
+      "@hooks": "./hooks",
+      "@lib": "./lib",
+      "@pages":  "./pages",
+      "@public":  "./public",
+      "@redux": "./redux",
+      "@test": "./test"
     }]
   ]
 }

--- a/next/components/landing/Header/style.tsx
+++ b/next/components/landing/Header/style.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Logo from 'assets/svg/logo.svg';
+import Logo from '@assets/svg/logo.svg';
 import media from '~/components/globalStyles/media';
 
 export const HeaderContainer = styled.header`

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { join } = require('path');
-
 /**
  * @type {import('next/dist/next-server/server/config').NextConfig}
  * */

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -1,13 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { resolve } = require('path');
+const { join } = require('path');
 
 /**
  * @type {import('next/dist/next-server/server/config').NextConfig}
  * */
 module.exports = {
   webpack: (config) => {
-    config.resolve.alias['~'] = resolve(__dirname);
-    config.resolve.alias.assets = resolve(__dirname, './public/assets');
     config.module.rules.push({
       // 웹팩설정에 로더 추가함
       test: /\.svg$/,

--- a/next/tsconfig.json
+++ b/next/tsconfig.json
@@ -21,7 +21,15 @@
     "jsxImportSource": "@emotion/react",
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./*"]
+      "~/*": ["./*"],
+      "@assets/*": ["./public/assets/*"],
+      "@components/*": ["./components/*"],
+      "@hooks/*": ["./hooks/*"],
+      "@lib/*": ["./lib/*"],
+      "@pages/*":  ["./pages/*"],
+      "@public/*":  ["./public/*"],
+      "@redux/*": ["./redux/*"],
+      "@test/*": ["./test/*"],
     }
   },
   "include": [


### PR DESCRIPTION
# Summary
* 주요 디렉터리에 대한 path alias 를 추가하였습니다.
* path alias 구분은 접두사 (prefix) 를 지정해 주는 것이 좋습니다. ( 일반 경로와 구분 )
* [docs](https://nextjs.org/docs/advanced-features/module-path-aliases) next webpack 설정에서 alias 를 지정해주지 않아도, 알아서 tsconfig.json 을 참고합니다.
