### PR TITLE
FEAT: 로그인 페이지 퍼블리싱 및 기본 기능

### DIFF
--- a/next/components/common/Input/components.tsx
+++ b/next/components/common/Input/components.tsx
@@ -53,17 +53,18 @@ export const PasswordInput = ({
 /**
  * @desc input(type="email") 컴포넌트입니다.
  * 현재 입력 중인 값을 취소할 수 있는 버튼을 가졌습니다.
- * useState hook의 리턴값인 value, setValue 를 인자로 받습니다.
+ * @param isEmail: 이메일 값 존재 여부를 알 수 있는 boolean. 값을 Boolean형식으로 변경해서 넣어주세요.
+ * @param resetEmail: 이메일을 빈 문자열로 세팅할 수 있는 콜백 함수
  */
 export const EmailInput = ({
   forwardedRef,
   scale = DEFAULT_SCALE,
-  value,
-  setValue,
+  isEmail,
+  resetEmail,
   ...rest
 }: IEmailProps) => (
   <S.RelativeWrapper>
-    <S.DefaultInput ref={forwardedRef} scale={scale} value={value} {...rest} />
-    {value && <S.DeleteButton onClick={() => setValue('email', '')} />}
+    <S.DefaultInput ref={forwardedRef} scale={scale} {...rest} />
+    {isEmail && <S.DeleteButton onClick={() => resetEmail()} />}
   </S.RelativeWrapper>
 );

--- a/next/components/common/Input/typings.ts
+++ b/next/components/common/Input/typings.ts
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, Dispatch, SetStateAction } from 'react';
 import { UseFormSetValue } from 'react-hook-form';
 
 export interface IDefaultProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -14,8 +14,8 @@ export interface IPasswordUniqueProps {
 export type IPasswordProps = IDefaultProps & IPasswordUniqueProps;
 
 export interface IEmailUniqueProps {
-  value: string | number;
-  setValue: UseFormSetValue<{ email: string | null }>;
+  isEmail: boolean;
+  resetEmail: () => void;
 }
 export type IEmailProps = IDefaultProps & IEmailUniqueProps;
 

--- a/next/components/landing/ContentBlock/LeftContentBlock/index.tsx
+++ b/next/components/landing/ContentBlock/LeftContentBlock/index.tsx
@@ -53,7 +53,8 @@ const LeftContentBlock = ({
                     ref={emailEl}
                     type="email"
                     value={email}
-                    setValue={setEmail}
+                    isEmail={Boolean(email)}
+                    resetEmail={() => setEmail('')}
                     onChange={onChangeEmail}
                     placeholder="이메일 입력"
                     spellCheck="false"

--- a/next/components/landing/Header/index.tsx
+++ b/next/components/landing/Header/index.tsx
@@ -16,7 +16,7 @@ const Header = () => (
       </Box>
       <Box w="auto">
         <S.ButtonsWrapper>
-          <Link href="/login">
+          <Link href="/sign-in">
             <Button color="black" underline>
               로그인
             </Button>

--- a/next/components/sign-in/index.tsx
+++ b/next/components/sign-in/index.tsx
@@ -10,6 +10,7 @@ import Label from '@components/common/Label';
 import useDebugLog from '@hooks/useDebugLog';
 import { logInFetcher } from '@lib/fetchers';
 import { logAxiosError } from '@lib/apiClient';
+import { isDevelopment } from '@lib/enviroment';
 
 // TODO: 회원가입 컴포넌트 스타일 그대로 갖다쓰는데, 해당 스타일 공용화 시키기
 import * as CS from '@components/sign-up/common/styles';
@@ -73,6 +74,7 @@ const SignInForm = () => {
             type="email"
             id="email"
             placeholder="이메일 입력"
+            defaultValue={isDevelopment ? 'mogakco35@gmail.com' : undefined}
             scale="small"
             isEmail={Boolean(email)}
             resetEmail={() => setValue('email', '')}
@@ -88,6 +90,7 @@ const SignInForm = () => {
             type="password"
             id="password"
             placeholder="비밀번호 입력"
+            defaultValue={isDevelopment ? 'mogapass' : undefined}
             scale="small"
             onClickEye={onClickEye}
             isVisible={isVisiblePassword}

--- a/next/components/sign-in/index.tsx
+++ b/next/components/sign-in/index.tsx
@@ -17,8 +17,8 @@ import * as CS from '@components/sign-up/common/styles';
 import * as S from '@components/sign-up/Start/style';
 
 export type FormInputs = {
-  email: string | null;
-  password: string | null;
+  email: string;
+  password: string;
 };
 
 const SignInForm = () => {
@@ -37,7 +37,7 @@ const SignInForm = () => {
 
   const onSubmit = (signInInfo: UnpackNestedValue<FormInputs>) => {
     setLoginLoading(true);
-    logInFetcher(signInInfo as ILoginProps)
+    logInFetcher(signInInfo)
       .then(() => {
         // TODO: 서비스 페이지로 이동하기
         debugLog('로그인 성공 응답');

--- a/next/components/sign-in/index.tsx
+++ b/next/components/sign-in/index.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import { UnpackNestedValue, useForm } from 'react-hook-form';
 
-import type { ILoginProps } from 'typings/auth';
 import Form from '@components/common/Form';
 import Input from '@components/common/Input';
 import InputWrapper from '@components/common/InputWrapper';

--- a/next/components/sign-in/index.tsx
+++ b/next/components/sign-in/index.tsx
@@ -10,12 +10,10 @@ import Label from '@components/common/Label';
 import useDebugLog from '@hooks/useDebugLog';
 import { logInFetcher } from '@lib/fetchers';
 import { logAxiosError } from '@lib/apiClient';
-import { emailRule, passwordRule } from '@lib/regex';
 
 // TODO: 회원가입 컴포넌트 스타일 그대로 갖다쓰는데, 해당 스타일 공용화 시키기
 import * as CS from '@components/sign-up/common/styles';
 import * as S from '@components/sign-up/Start/style';
-import isAllPropertyTruthy from '@lib/isAllPropertyTruthy';
 
 export type FormInputs = {
   email: string | null;
@@ -24,7 +22,7 @@ export type FormInputs = {
 
 const SignInForm = () => {
   const router = useRouter();
-  const [loginLoading, setLoginLoading] = useState<boolean>(false);
+  const [signInLoading, setLoginLoading] = useState<boolean>(false);
   const [isVisiblePassword, setIsVisiblePassword] = useState(false);
   const onClickEye = () => setIsVisiblePassword((prev) => !prev);
   const debugLog = useDebugLog();
@@ -36,12 +34,13 @@ const SignInForm = () => {
     debugLog('미구현 기능입니다');
   };
 
-  const onSubmit = (loginInfo: UnpackNestedValue<FormInputs>) => {
-    console.log('loginInfo', loginInfo);
+  const onSubmit = (signInInfo: UnpackNestedValue<FormInputs>) => {
     setLoginLoading(true);
-    logInFetcher(loginInfo as ILoginProps)
+    logInFetcher(signInInfo as ILoginProps)
       .then(() => {
         // TODO: 서비스 페이지로 이동하기
+        debugLog('로그인 성공 응답');
+        debugLog('서비스 페이지 미구현 상태이므로 임시 경로(/)로 이동합니다');
         setLoginLoading(false);
         router.push('/');
       })
@@ -95,7 +94,7 @@ const SignInForm = () => {
             {...register('password', { required: true })}
           />
         </InputWrapper>
-        <CS.SubmitButton type="submit" fullWidth $loading={loginLoading}>
+        <CS.SubmitButton type="submit" fullWidth $loading={signInLoading}>
           이메일로 로그인
         </CS.SubmitButton>
       </Form>

--- a/next/components/sign-in/index.tsx
+++ b/next/components/sign-in/index.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import Form from '@components/common/Form';
+import Input from '@components/common/Input';
+import InputWrapper from '@components/common/InputWrapper';
+import Label from '@components/common/Label';
+
+import * as CS from '@components/sign-up/common/styles';
+import * as S from '@components/sign-up/Start/style';
+
+export type FormInputs = {
+  email: string | null;
+};
+
+const SignInForm = () => {
+  const [loginLoading, setLoginLoading] = useState<boolean>(false);
+  const [isVisiblePassword, setIsVisiblePassword] = useState(false);
+  const onClickEye = () => setIsVisiblePassword((prev) => !prev);
+
+  const { getValues, setValue } = useForm<FormInputs>();
+
+  return (
+    <>
+      <CS.Title>로그인</CS.Title>
+      <S.SocialLoginWrapper>
+        <S.SocialAnchor service="google" href="#">
+          <S.GoogleIcon />
+          <span>Google을 사용하여 로그인</span>
+        </S.SocialAnchor>
+        <S.SocialAnchor service="github" href="##">
+          <S.GithunIcon />
+          <span>Github을 사용하여 로그인</span>
+        </S.SocialAnchor>
+      </S.SocialLoginWrapper>
+      <S.DevideLine />
+      <Form action="">
+        <InputWrapper>
+          <Label htmlFor="email" direction="bottom">
+            이메일
+          </Label>
+          <Input
+            type="email"
+            id="email"
+            placeholder="이메일 입력"
+            scale="small"
+            isEmail={Boolean(getValues('email'))}
+            resetEmail={() => setValue('email', '')}
+            spellCheck="false"
+          />
+        </InputWrapper>
+        <InputWrapper>
+          <Label htmlFor="password" direction="bottom">
+            비밀번호
+          </Label>
+          <Input
+            type="password"
+            id="password"
+            scale="small"
+            onClickEye={onClickEye}
+            isVisible={isVisiblePassword}
+          />
+        </InputWrapper>
+        <S.SubmitButton type="submit" fullWidth $loading={loginLoading}>
+          이메일로 로그인
+        </S.SubmitButton>
+      </Form>
+    </>
+  );
+};
+
+export default SignInForm;

--- a/next/components/sign-up/Start/index.tsx
+++ b/next/components/sign-up/Start/index.tsx
@@ -101,12 +101,16 @@ const Start = () => {
           <S.DevideLine />
           <Form action="" onSubmit={handleSubmit(onSubmitEmail, onError)}>
             <InputWrapper>
-              <Label direction="bottom">이메일</Label>
+              <Label htmlFor="email" direction="bottom">
+                이메일
+              </Label>
               <Input
                 type="email"
+                id="email"
                 placeholder="이메일 입력"
                 scale="medium"
-                setValue={setValue}
+                isEmail={Boolean(getValues('email'))}
+                resetEmail={() => setValue('email', '')}
                 spellCheck="false"
                 {...register('email', { pattern: emailRule })}
               />

--- a/next/components/sign-up/Start/index.tsx
+++ b/next/components/sign-up/Start/index.tsx
@@ -29,8 +29,11 @@ const Start = () => {
   });
   const [emailTestError, setEmailTestError] = useState(false);
   const submitButtonEl = useRef<HTMLButtonElement>(null);
-  const { register, handleSubmit, setValue, getValues } = useForm<FormInputs>();
+  const { register, handleSubmit, setValue, getValues, watch } =
+    useForm<FormInputs>();
   const debugLog = useDebugLog();
+
+  const { email: watchedEmail } = watch();
 
   const onSubmitEmail = ({ email }: UnpackNestedValue<FormInputs>) => {
     setEmailTestError(false);
@@ -109,7 +112,7 @@ const Start = () => {
                 id="email"
                 placeholder="이메일 입력"
                 scale="medium"
-                isEmail={Boolean(getValues('email'))}
+                isEmail={Boolean(watchedEmail)}
                 resetEmail={() => setValue('email', '')}
                 spellCheck="false"
                 {...register('email', { pattern: emailRule })}

--- a/next/components/sign-up/Start/index.tsx
+++ b/next/components/sign-up/Start/index.tsx
@@ -18,7 +18,7 @@ import * as CS from '../common/styles';
 import * as S from './style';
 
 export type FormInputs = {
-  email: string | null;
+  email: string;
 };
 
 const Start = () => {

--- a/next/lib/isAllPropertyTruthy.ts
+++ b/next/lib/isAllPropertyTruthy.ts
@@ -1,10 +1,8 @@
-type AnyObject = Record<string, unknown>;
+type AnyObject = Record<string, any>;
 
 const isAllPropertyTruthy = <T extends AnyObject>(obj: T) => {
-  return Object.values(obj).reduce(
-    (prev, curr) => prev && Boolean(curr),
-    true,
-  ) as boolean;
+  if (Object.values(obj).length === 0) return false;
+  return Object.values(obj).reduce((prev, curr) => prev && Boolean(curr));
 };
 
 export default isAllPropertyTruthy;

--- a/next/pages/sign-in.tsx
+++ b/next/pages/sign-in.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import CustomHead from '@components/common/CustomHead';
+import AuthContainer from '@components/common/AuthContainer';
+import ProgressBar from '@components/sign-up/ProgressBar';
+import SignInForm from '@components/sign-in';
+
+export const pageProps = {
+  title: '로그인 - Mogakco',
+  description: 'Free online video chat for developers',
+  url: '', // TODO: 도메인 정해지면 url에 추가하기
+  locale: 'ko_KR',
+};
+
+const SignIn = () => {
+  return (
+    <>
+      <CustomHead {...pageProps} />
+      <AuthContainer progressBar={<ProgressBar fill={0} />}>
+        <SignInForm />
+      </AuthContainer>
+    </>
+  );
+};
+
+export default SignIn;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/57123802/124297106-ad5b8b80-db95-11eb-89d6-dfbbeb619673.png)

로그인 페이지 퍼블리싱 및 API 요청 까지의 단순 기능이 포함된 PR입니다.
[#144](https://github.com/bear-bear-bear/mogakco/issues/144) 에서 설명되는 응답 값에 대한 로직은 아직 구현되지 않았습니다.

인풋 기본 값에 [#144](https://github.com/bear-bear-bear/mogakco/issues/144) 에서 말하는 모각코 기본 이메일 계정을 넣었는데, 해당 계정이 시딩에 구현되있진 않네용 ?

![image](https://user-images.githubusercontent.com/57123802/124297007-8f8e2680-db95-11eb-840c-108bcea2b9fd.png)
이메일 로그인 파트는 위처럼 되도록 추후 수정 예정입니다. 지금은 뭔가 구려.. 