### PR TITLE
FIX: 랜딩 이메일 첫 진입 시 포커스 삭제

### DIFF
--- a/next/components/landing/ContentBlock/LeftContentBlock/index.tsx
+++ b/next/components/landing/ContentBlock/LeftContentBlock/index.tsx
@@ -4,7 +4,6 @@ import Fade from 'react-reveal/Fade';
 import Image from 'next/Image';
 import { Box, Flex } from '@chakra-ui/react';
 
-import useIsomorphicLayoutEffect from '@hooks/useIsomorphicLayoutEffect';
 import useInput from '@hooks/useInput';
 import type { ILeftContentBlockProps } from '@components/landing/ContentBlock';
 
@@ -19,13 +18,6 @@ const LeftContentBlock = ({
 }: ILeftContentBlockProps) => {
   const router = useRouter();
   const [email, onChangeEmail, setEmail] = useInput('');
-
-  useIsomorphicLayoutEffect(() => {
-    if (!isFirstBlock) {
-      return;
-    }
-    emailEl?.current?.focus();
-  }, [emailEl, isFirstBlock]);
 
   const toSignUp = (e: SyntheticEvent) => {
     e.preventDefault();


### PR DESCRIPTION
FOCUS 이벤트가 발생하면 해당 엘리먼트를 정중앙으로 위치시키도록 뷰박스가 이동하는데, 랜딩 페이지 진입 시 email ref로 포커스 되는 기존 기능이  모바일 환경에서 작동 시 뷰박스 이동이로 헤더가 안보이고 svg 이미지가 짤려보이는 문제를 발견. 해당 기능을 삭제했습니다.