### PR TITLE
feat: Socket.io 4.2.3 으로 Server, Client Socket 연결 작성

### DIFF
--- a/nest/package-lock.json
+++ b/nest/package-lock.json
@@ -2100,6 +2100,15 @@
         }
       }
     },
+    "@types/socket.io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-3.0.2.tgz",
+      "integrity": "sha512-pu0sN9m5VjCxBZVK8hW37ZcMe8rjn4HHggBN5CbaRTvFwv5jOmuIRZEuddsBPa9Th0ts0SIo3Niukq+95cMBbQ==",
+      "dev": true,
+      "requires": {
+        "socket.io": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",

--- a/nest/package.json
+++ b/nest/package.json
@@ -93,6 +93,7 @@
     "@types/node": "^16.7.10",
     "@types/passport-jwt": "^3.0.6",
     "@types/passport-local": "^1.0.34",
+    "@types/socket.io": "^3.0.2",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",

--- a/nest/src/models/chat/chat.gateway.ts
+++ b/nest/src/models/chat/chat.gateway.ts
@@ -12,7 +12,7 @@ import ChatService from './chat.service';
 /**
  * @ClientIdentifier client 의 conn.id
  */
-@WebSocketGateway({ namespace: 'chat' })
+@WebSocketGateway({ namespace: 'chat', cors: { origin: '*', credentials: true } })
 class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server!: Server;

--- a/next/hooks/useSocket.tsx
+++ b/next/hooks/useSocket.tsx
@@ -7,7 +7,7 @@ export default function useSocket() {
   const [socket, setSocket] = useState<typeof Socket | undefined>(undefined);
 
   const connect = useCallback(() => {
-    const socketIO = io.connect(SOCKET_SERVER);
+    const socketIO = io(SOCKET_SERVER);
     setSocket(socketIO);
   }, []);
 

--- a/next/hooks/useSocketTest.tsx
+++ b/next/hooks/useSocketTest.tsx
@@ -1,0 +1,15 @@
+import useSWR from 'swr';
+import SocketIOClient from 'socket.io-client';
+
+export const SOCKET_TEST_KEY = 'socket-test';
+const SOCKET_SERVER = 'http://localhost:8001';
+
+export default function useSocketTest() {
+  const { data: client, mutate } = useSWR(SOCKET_TEST_KEY, () =>
+    SocketIOClient(SOCKET_SERVER),
+  );
+  return {
+    client,
+    mutate,
+  };
+}

--- a/next/pages/video-chat/[id].tsx
+++ b/next/pages/video-chat/[id].tsx
@@ -6,7 +6,6 @@ import Container from '@components/video-chat/Container';
 import CamSection from '@components/video-chat/CamSection';
 import ChatSection from '@components/video-chat/ChatSection';
 import useUser from '@hooks/useUser';
-import useSocket from '@hooks/useSocket';
 import apiClient, { logAxiosError } from '@lib/apiClient';
 import devModeLog from '@lib/devModeLog';
 import type { GeneralAxiosError } from 'typings/common';
@@ -14,6 +13,7 @@ import type { IUserGetSuccessResponse } from 'typings/auth';
 import { GetServerSideProps } from 'next';
 import { refreshAccessTokenApiSSR } from '@lib/apis';
 import token from '@lib/token';
+import useSocketTest from '@hooks/useSocketTest';
 
 const pageProps = {
   title: '화상채팅 - Mogakco',
@@ -25,23 +25,23 @@ const pageProps = {
 const ChatRoom = () => {
   const router = useRouter();
   const { user } = useUser({ redirectTo: '/' });
-  const socket = useSocket();
-  socket?.emit('events', { text: 'text' });
-  devModeLog({ socket, user });
+  const { client } = useSocketTest();
+  client?.emit('events', { text: 'text' });
+  devModeLog({ client, user });
 
   useEffect(() => {
-    if (!socket || !user?.isLoggedIn) return;
+    if (!client || !user?.isLoggedIn) return;
 
-    socket.on('test', (data: string) => devModeLog({ data }));
+    client.on('test', (data: string) => devModeLog({ data }));
     const { id: userId } = user as IUserGetSuccessResponse;
     const props: any = {
       userId,
       roomId: String(router.query.id),
     };
 
-    socket.emit('join-chat-room', props);
-    socket.emit('events', { name: 'Nest' }, (data: string) => devModeLog(data));
-  }, [router.query.id, socket, user]);
+    client.emit('join-chat-room', props);
+    client.emit('events', { name: 'Nest' }, (data: string) => devModeLog(data));
+  }, [router.query.id, client, user]);
 
   if (!user?.isLoggedIn) return null;
   return (


### PR DESCRIPTION
# Summary
* 서버, 클라이언트 모두 소켓 라이브러리 버전을 4.2.3 을 맞췄습니다. ( 서버 types 3.x 정상 )
* 클라이언트에서 임시 테스트용 소켓 연결 훅을 작성하고, 채팅방에서 소켓 연결이 성립되는 것을 확인하였습니다.