### PR TITLE
feat: 로그아웃 상태일 때 accessToken 갱신 방지

### DIFF
--- a/nest/src/authentication/auth.service.ts
+++ b/nest/src/authentication/auth.service.ts
@@ -66,7 +66,7 @@ export default class AuthService {
       token,
       maxAge: 6.048e8,
       path: '/',
-      httpOnly: true,
+      httpOnly: false,
     } as ICookieProps;
   }
 

--- a/next/components/sign-in/index.tsx
+++ b/next/components/sign-in/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import useUser from '@hooks/useUser';
+import type { UserMutator } from '@hooks/useUser';
 import Form from '@components/common/Form';
 import Input from '@components/common/Input';
 import InputWrapper from '@components/common/InputWrapper';
@@ -23,8 +23,7 @@ export type FormInputs = {
   password: string;
 };
 
-const SignInForm = () => {
-  const { mutateUser } = useUser();
+const SignInForm = ({ mutateUser }: UserMutator) => {
   const [signInLoading, setLoginLoading] = useState<boolean>(false);
   const [isVisiblePassword, setIsVisiblePassword] = useState<boolean>(false);
   const onClickEye = () => setIsVisiblePassword((prev) => !prev);

--- a/next/components/sign-up/Optional/index.tsx
+++ b/next/components/sign-up/Optional/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, SyntheticEvent } from 'react';
 import { OptionsType } from 'react-select';
 
-import useUser from '@hooks/useUser';
+import type { UserMutator } from '@hooks/useUser';
 import getSessionStorageValues from '@lib/getSessionStorageValues';
 import Select from '@components/common/Select';
 import Desc from '@components/common/Desc';
@@ -20,8 +20,11 @@ import * as CS from '../common/styles';
 
 const SKILLS_LIMIT = 5;
 
-const Optional = ({ skillOptions, jobOptions }: IOptionalPageProps) => {
-  const { mutateUser } = useUser();
+const Optional = ({
+  skillOptions,
+  jobOptions,
+  mutateUser,
+}: IOptionalPageProps & UserMutator) => {
   const [signUpLoading, setSignUpLoading] = useState<boolean>(false);
   const [isShowSkillOptions, setIsShowSkillOptions] = useState<boolean>(true);
   const [skillIds, setSkillIds] = useState<number[] | null>(null);

--- a/next/hooks/useUser.tsx
+++ b/next/hooks/useUser.tsx
@@ -3,20 +3,20 @@ import { useRouter } from 'next/router';
 import useSWR from 'swr';
 import type { SWRConfiguration } from 'swr';
 
+import { isRefreshTokenInCookie } from '@lib/token';
 import fetcher from '@lib/fetcher';
-// import devModeLog from '@lib/devModeLog';
+
 import type {
   IUserGetSuccessResponse,
   IUserGetFailureResponse,
 } from 'typings/auth';
 
-// useUser props
 interface IProps {
   redirectTo?: `/${string}`;
   redirectIfFound?: boolean;
 }
 
-// SWRConfiguration
+const SWRKey = isRefreshTokenInCookie() ? '/api/auth/user' : null;
 const SWROptions: SWRConfiguration<
   IUserGetSuccessResponse,
   IUserGetFailureResponse
@@ -61,15 +61,13 @@ export default function useUser({
   const { data: user, mutate: mutateUser } = useSWR<
     IUserGetSuccessResponse,
     IUserGetFailureResponse
-  >('/api/auth/user', fetcher, SWROptions);
+  >(SWRKey, fetcher, SWROptions);
 
   useEffect(() => {
     // 리디렉트가 필요하지 않다면 return (예: 이미 /dashboard에 있음)
     if (!redirectTo) return;
     // 사용자 데이터가 아직 존재하지 않으면 return (패치 진행 중 일때 등)
     if (!user) return;
-
-    // devModeLog({ redirectTo, redirectIfFound, user });
 
     if (
       // redirectTo가 설정되어 있을 시, 사용자가 없을 때 리디렉션

--- a/next/hooks/useUser.tsx
+++ b/next/hooks/useUser.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
-import type { SWRConfiguration } from 'swr';
+import type { SWRConfiguration, KeyedMutator } from 'swr/dist/types';
 
 import { isRefreshTokenInCookie } from '@lib/token';
 import fetcher from '@lib/fetcher';
@@ -11,19 +11,18 @@ import type {
   IUserGetFailureResponse,
 } from 'typings/auth';
 
-interface IProps {
+interface UseUserProps {
   redirectTo?: `/${string}`;
   redirectIfFound?: boolean;
 }
 
-const SWRKey = isRefreshTokenInCookie() ? '/api/auth/user' : null;
+const SWR_CACHE_KEY = '/api/auth/user';
 const SWROptions: SWRConfiguration<
-  IUserGetSuccessResponse,
-  IUserGetFailureResponse
+  IUserGetSuccessResponse | IUserGetFailureResponse
 > = {
   onErrorRetry: (error, key, config, revalidate, { retryCount }) => {
     // Never url
-    if (key === '/api/auth/user') return;
+    if (key === SWR_CACHE_KEY) return;
 
     // count
     if (retryCount >= 10) return;
@@ -32,6 +31,9 @@ const SWROptions: SWRConfiguration<
   },
 };
 
+const getSWRKeyByRefreshTokenExist = () =>
+  isRefreshTokenInCookie() ? SWR_CACHE_KEY : null;
+
 /**
  * @desc
  * swr을 사용하여 user 정보를 받아와 리디렉션과 static generation을 담당합니다.
@@ -39,8 +41,8 @@ const SWROptions: SWRConfiguration<
  * swr fetcher가 axios 함수이므로 유저 정보 패치 전 인터셉터를 통해 현재 액세스 토큰의 유효성 여부 판단과 그에 따른 갱신 또한 이뤄지게 됩니다.
  * 요청에 대한 응답이 400, 401, 403, 404 등일 때, 재요청 폴링을 금지합니다.
  * ---
- * @param redirectTo {`/${string}`} (optional) 리디렉션 경로 - redirectTo가 설정되어 있을 시, 사용자가 없을 때 리디렉션
- * @param redirectIfFound {boolean} (optional) 리디렉션 경로 - redirectTo가 설정되어 있을 시, 사용자가 없을 때 리디렉션
+ * @param redirectTo {`/${string}`} (optional) 리디렉션 경로 - redirectTo가 설정되어 있을 시, 사용자가 없다면 리디렉션
+ * @param redirectIfFound {boolean} (optional) 리디렉션 경로 - redirectTo가 설정되어 있을 시, 사용자를 있다면 리디렉션
  * ---
  * @example
  * // 1. 유저가 없다면 '/' 경로로 리디렉션 됩니다.
@@ -56,11 +58,12 @@ const SWROptions: SWRConfiguration<
 export default function useUser({
   redirectTo,
   redirectIfFound = false,
-}: IProps = {}) {
+}: UseUserProps = {}) {
   const router = useRouter();
+
+  const SWRKey = redirectIfFound ? SWR_CACHE_KEY : getSWRKeyByRefreshTokenExist;
   const { data: user, mutate: mutateUser } = useSWR<
-    IUserGetSuccessResponse,
-    IUserGetFailureResponse
+    IUserGetSuccessResponse | IUserGetFailureResponse
   >(SWRKey, fetcher, SWROptions);
 
   useEffect(() => {
@@ -70,14 +73,21 @@ export default function useUser({
     if (!user) return;
 
     if (
-      // redirectTo가 설정되어 있을 시, 사용자가 없을 때 리디렉션
-      (redirectTo && !redirectIfFound && !user.isLoggedIn) ||
-      // redirectIfFound가 설정되어 있을 시, 사용자가 발견되면 리디렉션
-      (redirectTo && redirectIfFound && user.isLoggedIn)
+      // redirectIfFound false일때, 사용자가 없을 때 리디렉션
+      (!redirectIfFound && !user.isLoggedIn) ||
+      // redirectIfFound true일때, 사용자가 발견되면 리디렉션
+      (redirectIfFound && user.isLoggedIn)
     ) {
       router.push(redirectTo);
     }
   }, [redirectIfFound, redirectTo, router, user]);
 
   return { user, mutateUser };
+}
+
+/**
+ * @desc mutate를 props로 넘겨줄때 사용할 인터페이스
+ */
+export interface UserMutator {
+  mutateUser: KeyedMutator<IUserGetSuccessResponse | IUserGetFailureResponse>;
 }

--- a/next/lib/apiClient.ts
+++ b/next/lib/apiClient.ts
@@ -2,7 +2,12 @@ import axios, { AxiosRequestConfig } from 'axios';
 import log from 'loglevel';
 import devModeLog from '@lib/devModeLog';
 import { refreshAccessTokenApi } from '@lib/apis';
-import token, { memoryStorage, ACCESS_TOKEN, REFRESH_TOKEN } from '@lib/token';
+import token, {
+  memoryStorage,
+  ACCESS_TOKEN,
+  REFRESH_TOKEN,
+  isRefreshTokenByCookie,
+} from '@lib/token';
 import type { GeneralAxiosError } from 'typings/common';
 
 export const logAxiosError = (axiosError: GeneralAxiosError) => {
@@ -103,6 +108,8 @@ export const refreshAccessToken = async (config: AxiosRequestConfig) => {
 const processProlongToken = async (config: AxiosRequestConfig) => {
   if (typeof window === 'undefined') return config;
 
+  const isRefresh = isRefreshTokenByCookie();
+  if (!isRefresh) return config;
   // 인터셉트를 패스시켜야 할 url인지 검사
   const passUrlList = Object.values(passUrlDict);
   if (passUrlList.includes(config.url as string)) {

--- a/next/lib/token.ts
+++ b/next/lib/token.ts
@@ -47,8 +47,9 @@ export default token;
 /**
  * @desc refreshToken 이 존재하는 지 검사한다.
  */
-export function isRefreshTokenByCookie(): boolean {
+export const isRefreshTokenInCookie = () => {
   const { cookie } = document;
-  const match = cookie.match(/^(refreshToken=).*/);
-  return match !== null;
-}
+  const tokenRegex = /refreshToken=[^;]+;?/;
+
+  return tokenRegex.test(cookie);
+};

--- a/next/lib/token.ts
+++ b/next/lib/token.ts
@@ -30,7 +30,7 @@ const token = {
   },
 
   /**
-   * @decs
+   * @desc
    * 로그아웃과 함께 사용. 사전 합의된 위치의 액세스 토큰과 expiration을 삭제.
    * 리프레쉬 토큰은 서버단에서 쿠키에 자동으로 세팅해줌을 인지할 것
    */
@@ -43,3 +43,12 @@ const token = {
 } as const;
 
 export default token;
+
+/**
+ * @desc refreshToken 이 존재하는 지 검사한다.
+ */
+export function isRefreshTokenByCookie(): boolean {
+  const { cookie } = document;
+  const match = cookie.match(/^(refreshToken=).*/);
+  return match !== null;
+}

--- a/next/lib/token.ts
+++ b/next/lib/token.ts
@@ -48,6 +48,10 @@ export default token;
  * @desc refreshToken 이 존재하는 지 검사한다.
  */
 export const isRefreshTokenInCookie = () => {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
   const { cookie } = document;
   const tokenRegex = /refreshToken=[^;]+;?/;
 

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
-import useUser from '@hooks/useUser';
 
+import useUser from '@hooks/useUser';
 import Button from '@components/common/Button';
 import CustomHead from '@components/common/CustomHead';
 import Container from '@components/dashboard/Container';
@@ -30,9 +30,10 @@ const Dashboard = () => {
 
   const handleSignOut = async () => {
     try {
-      await signOutApi();
-      mutateUser(undefined);
+      mutateUser({ isLoggedIn: false }, false);
       token.delete();
+      await signOutApi();
+      mutateUser();
     } catch (error) {
       logAxiosError(error as GeneralAxiosError);
     }

--- a/next/pages/sign-in/index.tsx
+++ b/next/pages/sign-in/index.tsx
@@ -14,7 +14,7 @@ export const pageProps = {
 };
 
 const SignIn = () => {
-  const { user } = useUser({
+  const { user, mutateUser } = useUser({
     redirectTo: '/dashboard',
     redirectIfFound: true,
   });
@@ -24,7 +24,7 @@ const SignIn = () => {
     <>
       <CustomHead {...pageProps} />
       <AuthContainer progressBar={<ProgressBar fill={0} />}>
-        <SignInForm />
+        <SignInForm mutateUser={mutateUser} />
       </AuthContainer>
     </>
   );

--- a/next/pages/sign-up/optional.tsx
+++ b/next/pages/sign-up/optional.tsx
@@ -23,7 +23,7 @@ export interface IOptionalPageProps {
 }
 
 const SignUpOptional = (props: IOptionalPageProps) => {
-  const { user } = useUser({
+  const { user, mutateUser } = useUser({
     redirectTo: '/dashboard',
     redirectIfFound: true,
   });
@@ -33,7 +33,7 @@ const SignUpOptional = (props: IOptionalPageProps) => {
     <>
       <CustomHead {...pageProps} />
       <AuthContainer progressBar={<ProgressBar fill={100} />}>
-        <Optional {...props} />
+        <Optional mutateUser={mutateUser} {...props} />
       </AuthContainer>
     </>
   );


### PR DESCRIPTION
# Summary
* 첫 번째로 로그아웃 상태인 지 검사하고 인터셉터 과정을 패스합니다.
* 변경된 로직에 적응치 않고, 본인 정신 정상 상태에서 개발되지 않았으니 검사 부탁드립니다.
* 기존 HttpOnly 를 false 로 해둔 이유가 jwt 값은 키 없이 복호화해볼 수 없기 때문이었습니다.

Closes #295

---
# addition by @bear-bear-bear 
**useUser 훅스에서 발생하던 아래 문제들 수정**
- 컴포넌트의 useUser 가 부모 페이지의 useUser props 값을 덮어버리는 문제
- 리다이렉션이 제대로 수행되지 않는 문제
- 타입 설정이 잘못되어 있던 문제
- 불필요한 조건절이 들어가있던 문제
추가기능 - user가 필요한 페이지에선 리프레쉬 토큰이 쿠키에 존재할때만 요청을 보내도록 설정 (즉, 리프레쉬 토큰이 없을 경우 user가 없는 것으로 가정) - 사용자가 고의적으로, 혹은 인지하지 못한 상태로 쿠키를 지울경우에 대한 리디렉션 로직은 다음 PR에 올리겠습니다.