### PR TITLE
fix: useUser 타입문제 수정

### DIFF
--- a/nest/src/authentication/auth.controller.ts
+++ b/nest/src/authentication/auth.controller.ts
@@ -250,11 +250,8 @@ class AuthController {
       };
     }
     const { isLoggedIn, user } = await this.authService.getAuthentication(accessToken);
-    if (!isLoggedIn) {
-      res.status(HttpStatus.UNAUTHORIZED);
-      return { statusCode: HttpStatus.UNAUTHORIZED, message: '인증 권한이 없습니다.' };
-    }
-    return { statusCode: HttpStatus.OK, ...user, message: '유저가 존재합니다.' };
+
+    return !isLoggedIn ? { isLoggedIn } : { isLoggedIn, ...user };
   }
 }
 

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -31,8 +31,8 @@ const Dashboard = () => {
   const handleSignOut = async () => {
     try {
       mutateUser({ isLoggedIn: false }, false);
-      token.delete();
       await signOutApi();
+      token.delete();
       mutateUser();
     } catch (error) {
       logAxiosError(error as GeneralAxiosError);

--- a/next/pages/video-chat/[id].tsx
+++ b/next/pages/video-chat/[id].tsx
@@ -12,6 +12,7 @@ import token from '@lib/token';
 import { useRouter } from 'next/router';
 import useSocket from '@hooks/useSocket';
 import { useEffect } from 'react';
+import type { IUserInfo } from 'typings/auth';
 
 const pageProps = {
   title: '화상채팅 - Mogakco',
@@ -28,9 +29,9 @@ const ChatRoom = () => {
 
   useEffect(() => {
     if (!client || !user?.isLoggedIn) return;
+    const { id: userId } = user as IUserInfo;
 
-    const { id: userId } = user;
-    const props: { userId: number; roomId: string } = {
+    const props = {
       userId,
       roomId: String(router.query.id),
     };

--- a/next/typings/auth.ts
+++ b/next/typings/auth.ts
@@ -42,15 +42,8 @@ export interface IUserInfo {
 /**
  * 토큰으로 유저 정보를 요청했을 떄의 성공 응답
  */
-export interface IUserGetSuccessResponse extends IUserInfo {
+export interface IUserGetResponse extends Partial<IUserInfo> {
   isLoggedIn: boolean; // true
-}
-
-/**
- * 토큰으로 유저 정보를 요청했을 떄의 실패 응답
- */
-export interface IUserGetFailureResponse {
-  isLoggedIn: boolean; // false
 }
 
 /**


### PR DESCRIPTION
# Summary
**결국 isLoggedIn 을 사용하기로 했습니다**. 미안합니다. 백측은 복구해뒀습니다.

isLoggedIn을 사용하면 '유저 정보없음' (user.isLoggedIn === false) 상태와 '아직 데이터를 요청하지 않음'(user === undefined)을 구분할 수 있습니다. 하지만 isLoggedIn을 사용하지 않으면 이를 구분할 수 없습니다. 둘 다 undefined 거든요.

둘을 구분할 수 없을때 생기는 문제는 다음과 같습니다.

1. swr은 데이터 패칭 중 조건부 가져오기 또는 종속 가져오기와 함께 사용할 때 요청이 일시 중지된 경우 data를 undefined로 띄웁니다. 이 때 리디렉션 로직을 멈추지 않으면 리디렉션 로직상 무한 루프가 발생하는데, 기존에는 user가 undefined라면 `if (!user) return` 했기때문에 문제가 발생하지 않았지만 isLoggedIn을 삭제하고 user가 있냐, 없냐로만 판단하는 변경 후 로직은 `if (!user) return`를 쓸 수 없습니다.

더 문제가 많은데 머릿속 정리가 안되어 하나만 씁니당 ㅋㅋ.. 굉장히 여러 방면으로 시도해봤는데, 현재 로직상 isLoggedIn 사용은 불가피한듯 합니다.

---
# Feature
타입을 다음과 같이 변경했습니다.
``` ts
// BEFORE
/**
 * 토큰으로 유저 정보를 요청했을 떄의 성공 응답
 */
export interface IUserGetResponse extends IUserInfo {
  isLoggedIn: boolean; // true
}
/**
 * 토큰으로 유저 정보를 요청했을 떄의 실패 응답
 */
export interface IUserGetFailureResponse {
  isLoggedIn: boolean; // false
}

// AFTER
/**
 * 토큰으로 유저 정보를 요청했을 떄의 응답
 */
export interface IUserGetResponse extends Partial<IUserInfo> {
  isLoggedIn: boolean; // true
}
```

---
SWR data는 기본적으로 undefined일 수도 있기 때문에, `!user?.isLoggedIn` 으로 걸러줍니다.
isLoggedIn 이 true라면 나머지 유저정보가 모두 있단겁니다. 근데 TS 가 멍청해서 이걸 모르니, 아래 코드처럼 타입 단언에서 쓰시면 됩니다. 섹시하지 못해 미안합니다.

![image](https://user-images.githubusercontent.com/57123802/132869515-29a3b769-d823-4c3c-a84f-dae04b1e9f60.png)
