### PR TITLE
feat: 서비스 헤더를 대시보드 페이지에도 적용하고 그에 맞춰 스타일 보완

### DIFF
--- a/next/components/common/Profile/ProfileModal.tsx
+++ b/next/components/common/Profile/ProfileModal.tsx
@@ -1,7 +1,8 @@
+import React, { useState, useCallback } from 'react';
 import Link from 'next/link';
 
 import useUser from '@hooks/useUser';
-import { signOutApi } from '@lib/apis';
+import { authProlongTestApi, signOutApi } from '@lib/apis';
 import token from '@lib/token';
 import { logAxiosError } from '@lib/apiClient';
 import type { GeneralAxiosError } from 'typings/common';
@@ -16,6 +17,10 @@ export interface ProfileModalProps {
 
 const ProfileModal = ({ isShow, direction }: ProfileModalProps) => {
   const { user, mutateUser } = useUser();
+
+  const onClickTestButton = async () => {
+    await authProlongTestApi();
+  };
 
   const handleSignOut = async () => {
     try {
@@ -52,11 +57,20 @@ const ProfileModal = ({ isShow, direction }: ProfileModalProps) => {
           </li>
           <li>
             <button
-              className="profile-section__list__item"
               type="button"
+              className="profile-section__list__item"
               onClick={handleSignOut}
             >
               로그아웃
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className="profile-section__list__item"
+              onClick={onClickTestButton}
+            >
+              로그인 연장 테스트
             </button>
           </li>
         </ul>

--- a/next/components/common/Profile/index.tsx
+++ b/next/components/common/Profile/index.tsx
@@ -4,7 +4,7 @@ import ProfileModal from './ProfileModal';
 
 import * as S from './style';
 
-interface ProfileProps {
+export interface ProfileProps {
   modalDirection: 'left' | 'right';
 }
 

--- a/next/components/common/Profile/style.tsx
+++ b/next/components/common/Profile/style.tsx
@@ -18,6 +18,7 @@ export const ProfileModal = styled.section<ProfileModalProps>`
   width: 18rem;
   max-width: 100vw;
   position: absolute;
+  z-index: 9999;
   transform: ${({ direction }) =>
     direction === 'left'
       ? `translateX(calc(-100% + ${iconLength}rem))`
@@ -28,6 +29,7 @@ export const ProfileModal = styled.section<ProfileModalProps>`
   padding: 1.33rem 1rem;
   box-shadow: 0 0 1px var(--color-gray-2), 0 0 2px var(--color-gray-2);
   border-radius: 16px;
+  background-color: var(--color-white);
 
   .profile-section {
     header {

--- a/next/components/common/ServiceHeader/style.tsx
+++ b/next/components/common/ServiceHeader/style.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
 
 export const ServiceHeader = styled.header`
-  grid-area: header;
+  /* grid-area: header; */
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding: 1.33rem 1rem;
 `;

--- a/next/components/dashboard/Container/style.tsx
+++ b/next/components/dashboard/Container/style.tsx
@@ -3,12 +3,8 @@ import media, { mediaBreakpoints } from '@components/globalStyles/media';
 
 export const Container = styled.main`
   width: 100%;
-  height: 100%;
   max-width: ${mediaBreakpoints.lg}px;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -16,6 +12,10 @@ export const Container = styled.main`
 
   ${media.sm} {
     height: initial;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     flex-direction: row;
     align-items: initial;
     justify-content: space-around;

--- a/next/components/globalStyles/_Variables.tsx
+++ b/next/components/globalStyles/_Variables.tsx
@@ -4,7 +4,7 @@ const Variables = css`
   :root {
     // -- COLORS --
     --color-black: #010409;
-    --color-white: #f0f6fc;
+    --color-white: #fefefe;
     --color-white-real: #ffffff;
     --color-gray-0: #f0f6fc;
     --color-gray-1: #c9d1d9;

--- a/next/components/globalStyles/index.tsx
+++ b/next/components/globalStyles/index.tsx
@@ -12,6 +12,14 @@ export const customGlobalStyles = css`
     box-sizing: border-box;
   }
 
+  html,
+  body,
+  body > div:first-child,
+  div#__next,
+  div#__next > div {
+    min-height: 100vh;
+  }
+
   html {
     font-family: sans-serif;
     -ms-text-size-adjust: 100%;

--- a/next/components/my-page/Container/style.tsx
+++ b/next/components/my-page/Container/style.tsx
@@ -3,10 +3,8 @@ import styled from '@emotion/styled';
 
 export const Container = styled.section`
   width: 100%;
-  height: 100vh;
   display: grid;
   grid-template:
-    'header' max-content
     'aside' max-content
     'main' max-content/
     1fr;
@@ -16,7 +14,6 @@ export const Container = styled.section`
 
   ${media.lg} {
     grid-template:
-      'header header' max-content
       'aside main' 1fr /
       12rem 1fr;
   }

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -1,15 +1,10 @@
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 
 import useUser from '@hooks/useUser';
-import Button from '@components/common/Button';
 import CustomHead from '@components/common/CustomHead';
 import Container from '@components/dashboard/Container';
 import CardLink from '@components/dashboard/CardLink';
-import { authProlongTestApi, signOutApi } from '@lib/apis';
-import token from '@lib/token';
-import { logAxiosError } from '@lib/apiClient';
-import type { GeneralAxiosError } from 'typings/common';
-import { isDevelopment } from '@lib/enviroment';
+import ServiceHeader from '@components/common/ServiceHeader';
 
 export const pageProps = {
   title: '대시보드 - Mogakco',
@@ -19,49 +14,14 @@ export const pageProps = {
 };
 
 const Dashboard = () => {
-  const { user, mutateUser } = useUser({ redirectTo: '/' });
-  const [isTestBtnLoading, setIsTestBtnLoading] = useState<boolean>(false);
-
-  const onClickTestButton = useCallback(async () => {
-    setIsTestBtnLoading(true);
-    await authProlongTestApi();
-    setIsTestBtnLoading(false);
-  }, []);
-
-  const handleSignOut = async () => {
-    try {
-      mutateUser({ isLoggedIn: false }, false);
-      await signOutApi();
-      token.delete();
-      mutateUser();
-    } catch (error) {
-      logAxiosError(error as GeneralAxiosError);
-    }
-  };
+  const { user } = useUser({ redirectTo: '/' });
 
   // TODO: 로그아웃 버튼 스타일, 위치 등 수정하기 (공용 헤더혹은 공용 버튼그룹으로 묶기)
   if (!user?.isLoggedIn) return null;
   return (
     <>
       <CustomHead {...pageProps} />
-      {user?.isLoggedIn && (
-        // 임시 위치, 임시 스타일
-        <Button style={{ float: 'right' }} outline onClick={handleSignOut}>
-          로그아웃
-        </Button>
-      )}
-      {user?.isLoggedIn && isDevelopment && (
-        // 임시 위치, 임시 스타일
-        <Button
-          type="button"
-          outline
-          style={{ float: 'right' }}
-          onClick={onClickTestButton}
-          $loading={isTestBtnLoading}
-        >
-          로그인 연장 테스트
-        </Button>
-      )}
+      <ServiceHeader />
       <Container>
         {/* <Link href={`/video-chat/${id}`}> */}
         {/* 임시로 화상채팅 1번 룸으로 가도록 설정 */}

--- a/next/pages/my-page/account-setting.tsx
+++ b/next/pages/my-page/account-setting.tsx
@@ -21,8 +21,8 @@ const MyPageAccountSetting = () => {
   return (
     <>
       <CustomHead {...pageProps} />
+      <ServiceHeader />
       <Container>
-        <ServiceHeader />
         <Aside />
         <Main />
       </Container>

--- a/next/pages/my-page/calendar.tsx
+++ b/next/pages/my-page/calendar.tsx
@@ -21,8 +21,8 @@ const MyPageCalendar = () => {
   return (
     <>
       <CustomHead {...pageProps} />
+      <ServiceHeader />
       <Container>
-        <ServiceHeader />
         <Aside />
         <Main />
       </Container>

--- a/next/pages/my-page/index.tsx
+++ b/next/pages/my-page/index.tsx
@@ -21,8 +21,8 @@ const MyPageDashboard = () => {
   return (
     <>
       <CustomHead {...pageProps} />
+      <ServiceHeader />
       <Container>
-        <ServiceHeader />
         <Aside />
         <Main />
       </Container>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57123802/132948370-431d4af7-0e3a-4b78-a16d-702271cfb73a.png)

채팅페이지에는 우측 상단 프로필 컴포넌트만 들어갈 예정입니다.
모달을 dialog element로 만들지 않은 이유는 브라우저 지원도 때문입니다.