### PR TITLE
feat: 계정 설정 페이지 Next api 임시 구현, 기능과 UI 작업 완료

### DIFF
--- a/next/src/components/common/Select/index.tsx
+++ b/next/src/components/common/Select/index.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, VFC } from 'react';
+import React, { ComponentProps } from 'react';
 import ReactSelect from 'react-select';
 import makeAnimated from 'react-select/animated';
 

--- a/next/src/components/common/Select/index.tsx
+++ b/next/src/components/common/Select/index.tsx
@@ -9,7 +9,9 @@ export interface SelectProps {
   value: string;
 }
 
-const MultipleSelect: VFC<ComponentProps<typeof ReactSelect>> = ({ props }) => (
+type Props = ComponentProps<typeof ReactSelect>;
+
+const MultipleSelect = (props: Props) => (
   <ReactSelect
     isMulti
     components={makeAnimated()}

--- a/next/src/components/my-page/AccountSetting/index.tsx
+++ b/next/src/components/my-page/AccountSetting/index.tsx
@@ -33,8 +33,6 @@ const AccountSetting = ({
   skillOptions,
   jobOptions,
 }: AccountSettingProps) => {
-  // FIXME: 새로고침마다 2~3회의 렌더링 발생 중
-  console.log('렌더링');
   const initialRequiredFields: RequiredFields = useMemo(
     () => ({
       username,
@@ -80,17 +78,6 @@ const AccountSetting = ({
     const isRequiredFieldsChanged = () =>
       !_.isEqual(initialRequiredFields, watchedRequiredFields);
 
-    console.log('검사', new Date().getSeconds());
-    console.log({
-      initialOptionalFieldsValue,
-      currOptionalFieldsValue,
-    });
-    console.log({
-      isRequiredFieldsValid,
-      isOptionalFieldsChanged: isOptionalFieldsChanged(),
-      isRequiredFieldsChanged: isRequiredFieldsChanged(),
-    });
-
     return (
       isRequiredFieldsValid &&
       (isOptionalFieldsChanged() || isRequiredFieldsChanged())
@@ -132,7 +119,6 @@ const AccountSetting = ({
 
         <S.DevideTextLine>선택 정보</S.DevideTextLine>
 
-        {/* TODO: select option 정상 렌더링 되는지 확인 */}
         <JobSelectSection
           options={jobOptions}
           setId={setJobId}
@@ -174,4 +160,4 @@ const AccountSetting = ({
   );
 };
 
-export default AccountSetting;
+export default React.memo(AccountSetting);

--- a/next/src/components/my-page/AccountSetting/index.tsx
+++ b/next/src/components/my-page/AccountSetting/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useCallback,
-  useState,
-  useRef,
-  useMemo,
-} from 'react';
+import { useEffect, useCallback, useState, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import _ from 'lodash';
 
@@ -18,6 +12,7 @@ import type { IOptionalPageProps as SelectsOptions } from '@pages/sign-up/option
 import type { IAccountEditProps, IUserInfo } from 'typings/auth';
 import type { GeneralAxiosError } from 'typings/common';
 
+import { cp } from 'fs/promises';
 import UsernameSection from './section/Username';
 import EmailSection from './section/Email';
 import JobSelectSection from './section/JobSelect';
@@ -40,6 +35,7 @@ const AccountSetting = ({
   skillOptions,
   jobOptions,
 }: AccountSettingProps) => {
+  console.log('렌더링');
   const [initialRequiredFields, setInitialRequiredFields] =
     useState<RequiredFields>({
       username,
@@ -73,7 +69,7 @@ const AccountSetting = ({
 
   const isSubmittable = useCallback(() => {
     const currOptionalFieldsValue: OptionalFieldsValue = {
-      skills: skillIds,
+      skills: skillIds && skillIds.sort((a, b) => Number(a) - Number(b)),
       job: jobId,
     };
 
@@ -119,23 +115,21 @@ const AccountSetting = ({
     };
 
     try {
-      const edittedUser = await editAccountApi(requestBody);
+      const {
+        email: edittedEmail,
+        username: edittedUsername,
+        skills: edittedSkills,
+        job: edittedJob,
+      } = await editAccountApi(requestBody);
 
       setInitialRequiredFields({
-        email: edittedUser.email,
-        username: edittedUser.username,
+        email: edittedEmail,
+        username: edittedUsername,
       });
       setInitialOptionalFieldsValue({
         skills:
-          edittedUser.skills &&
-          edittedUser.skills.map((skill) => skill.id.toString()),
-        job: edittedUser.job && edittedUser.job.id.toString(),
-      });
-
-      console.log({
-        edittedUser,
-        initialRequiredFields,
-        initialOptionalFieldsValue,
+          edittedSkills && edittedSkills.map((skill) => skill.id.toString()),
+        job: edittedJob && edittedJob.id.toString(),
       });
     } catch (err) {
       logAxiosError(err as GeneralAxiosError);
@@ -198,4 +192,4 @@ const AccountSetting = ({
   );
 };
 
-export default React.memo(AccountSetting);
+export default AccountSetting;

--- a/next/src/components/my-page/AccountSetting/index.tsx
+++ b/next/src/components/my-page/AccountSetting/index.tsx
@@ -12,7 +12,6 @@ import type { IOptionalPageProps as SelectsOptions } from '@pages/sign-up/option
 import type { IAccountEditProps, IUserInfo } from 'typings/auth';
 import type { GeneralAxiosError } from 'typings/common';
 
-import { cp } from 'fs/promises';
 import UsernameSection from './section/Username';
 import EmailSection from './section/Email';
 import JobSelectSection from './section/JobSelect';

--- a/next/src/components/my-page/AccountSetting/index.tsx
+++ b/next/src/components/my-page/AccountSetting/index.tsx
@@ -1,51 +1,108 @@
-import React, { useEffect, useCallback, useState, useRef } from 'react';
+import React, {
+  useEffect,
+  useCallback,
+  useState,
+  useRef,
+  useMemo,
+} from 'react';
 import { useForm } from 'react-hook-form';
 import _ from 'lodash';
 
 import Button from '@components/common/Button';
-import Warning from '@components/common/Warning';
-import InputWrapper from '@components/common/InputWrapper';
-import Label from '@components/common/Label';
-import { usernameRule, emailRule } from '@lib/regex';
-import JobSelect from '@components/sign-up/Optional/JobSelect';
-import SkillsSelect from '@components/sign-up/Optional/SkillsSelect';
+import toSelectOptions from '@lib/toSelectOptions';
 import type { IOptionalPageProps as SelectsOptions } from '@pages/sign-up/optional';
 import type { IUserInfo } from 'typings/auth';
 
-import toSelectOptions from '@lib/toSelectOptions';
+import UsernameSection from './section/Username';
+import EmailSection from './section/Email';
+import JobSelectSection from './section/JobSelect';
+import SkillsSelectSection from './section/SkillsSelect';
 import * as S from './style';
 
 interface AccountSettingProps extends SelectsOptions {
   user: IUserInfo;
 }
-type RequiredInfo = Pick<IUserInfo, 'username' | 'email'>;
+type RequiredFields = Pick<IUserInfo, 'username' | 'email'>;
+type OptionalFieldsValue = {
+  skills: string[] | null;
+  job: string | null;
+};
 
 const AccountSetting = ({
-  user: { id, skills, job, ...requiredInfo },
+  user: { id, skills, job, username, email },
   skillOptions,
   jobOptions,
 }: AccountSettingProps) => {
-  const defaultValues = requiredInfo;
+  // FIXME: 새로고침마다 2~3회의 렌더링 발생 중
+  console.log('렌더링');
+  const initialRequiredFields: RequiredFields = useMemo(
+    () => ({
+      username,
+      email,
+    }),
+    [email, username],
+  );
+  const initialOptionalFieldsValue: OptionalFieldsValue = useMemo(
+    () => ({
+      skills: skills?.map((skill) => skill.id.toString()) || null,
+      job: job?.id?.toString() || null,
+    }),
+    [skills, job],
+  );
 
-  const [skillIds, setSkillIds] = useState<string[] | null>(null);
-  const [jobId, setJobId] = useState<string | null>(null);
+  const [skillIds, setSkillIds] = useState<string[] | null>(
+    initialOptionalFieldsValue.skills,
+  );
+  const [jobId, setJobId] = useState<string | null>(
+    initialOptionalFieldsValue.job,
+  );
   const hiddenSubmitButtonEl = useRef<HTMLButtonElement>(null);
   const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true);
   const {
     register,
     handleSubmit,
     watch,
-    formState: { errors, isValid },
-  } = useForm<RequiredInfo>({
+    formState: { errors, isValid: isRequiredFieldsValid },
+  } = useForm<RequiredFields>({
     mode: 'all',
-    defaultValues,
+    defaultValues: initialRequiredFields,
   });
-  const watchedFields = watch();
+  const watchedRequiredFields = watch();
 
-  const isSubmittable = useCallback(
-    () => isValid && !_.isEqual(defaultValues, watchedFields),
-    [defaultValues, isValid, watchedFields],
-  );
+  const isSubmittable = useCallback(() => {
+    const currOptionalFieldsValue: OptionalFieldsValue = {
+      skills: skillIds,
+      job: jobId,
+    };
+
+    const isOptionalFieldsChanged = () =>
+      !_.isEqual(initialOptionalFieldsValue, currOptionalFieldsValue);
+    const isRequiredFieldsChanged = () =>
+      !_.isEqual(initialRequiredFields, watchedRequiredFields);
+
+    console.log('검사', new Date().getSeconds());
+    console.log({
+      initialOptionalFieldsValue,
+      currOptionalFieldsValue,
+    });
+    console.log({
+      isRequiredFieldsValid,
+      isOptionalFieldsChanged: isOptionalFieldsChanged(),
+      isRequiredFieldsChanged: isRequiredFieldsChanged(),
+    });
+
+    return (
+      isRequiredFieldsValid &&
+      (isOptionalFieldsChanged() || isRequiredFieldsChanged())
+    );
+  }, [
+    initialOptionalFieldsValue,
+    initialRequiredFields,
+    isRequiredFieldsValid,
+    jobId,
+    skillIds,
+    watchedRequiredFields,
+  ]);
 
   const handleAccountDeleteButtonClick = () => {
     alert('유저 삭제 미구현');
@@ -55,7 +112,7 @@ const AccountSetting = ({
     if (!isSubmittable()) return;
     hiddenSubmitButtonEl.current?.click();
   };
-  const handleFormSubmit = (info: RequiredInfo) => {
+  const handleFormSubmit = (info: RequiredFields) => {
     alert('submit');
     // TODO: 유저 정보 저장 요청 (PUT)
   };
@@ -70,59 +127,27 @@ const AccountSetting = ({
         <S.MainTitle>계정 설정</S.MainTitle>
       </header>
       <S.Form action="" onSubmit={handleSubmit(handleFormSubmit)}>
-        <InputWrapper>
-          <Label htmlFor="username" direction="bottom">
-            유저명
-          </Label>
-          <S.Input
-            type="text"
-            id="username"
-            spellCheck="false"
-            {...register('username', {
-              pattern: {
-                value: usernameRule,
-                message:
-                  '규칙에 맞는 유저명을 입력해주세요 (영문/한글/숫자/마침표 1-12자).',
-              },
-              required: true,
-            })}
-          />
-        </InputWrapper>
-        {errors.username && <Warning>{errors.username.message}</Warning>}
-        <InputWrapper>
-          <Label htmlFor="email" direction="bottom">
-            이메일
-          </Label>
-          <S.Input
-            type="text"
-            id="email"
-            spellCheck="false"
-            {...register('email', {
-              pattern: {
-                value: emailRule,
-                message: '올바른 형식의 이메일을 입력해주세요.',
-              },
-              required: true,
-            })}
-          />
-        </InputWrapper>
-        {errors.email && <Warning>{errors.email.message}</Warning>}
+        <UsernameSection register={register} errors={errors} />
+        <EmailSection register={register} errors={errors} />
 
         <S.DevideTextLine>선택 정보</S.DevideTextLine>
+
         {/* TODO: select option 정상 렌더링 되는지 확인 */}
-        <JobSelect
+        <JobSelectSection
           options={jobOptions}
           setId={setJobId}
           defaultValue={toSelectOptions(job)[0]}
         />
-        <SkillsSelect
+        <SkillsSelectSection
           options={skillOptions}
           setIds={setSkillIds}
           defaultValue={toSelectOptions(skills)}
         />
 
         <S.DevideTextLine />
+
         <Button
+          type="button"
           color="red"
           outline
           fullWidth
@@ -133,6 +158,7 @@ const AccountSetting = ({
 
         <S.HiddenButton ref={hiddenSubmitButtonEl} type="submit" />
       </S.Form>
+
       <S.Footer>
         <Button
           color="black"

--- a/next/src/components/my-page/AccountSetting/index.tsx
+++ b/next/src/components/my-page/AccountSetting/index.tsx
@@ -10,8 +10,13 @@ import _ from 'lodash';
 
 import Button from '@components/common/Button';
 import toSelectOptions from '@lib/toSelectOptions';
+import token from '@lib/token';
+import { logAxiosError } from '@lib/apiClient';
+import { deleteAccountApi } from '@lib/apis';
+import type { UserMutator } from '@hooks/useUser';
 import type { IOptionalPageProps as SelectsOptions } from '@pages/sign-up/optional';
 import type { IUserInfo } from 'typings/auth';
+import type { GeneralAxiosError } from 'typings/common';
 
 import UsernameSection from './section/Username';
 import EmailSection from './section/Email';
@@ -19,9 +24,10 @@ import JobSelectSection from './section/JobSelect';
 import SkillsSelectSection from './section/SkillsSelect';
 import * as S from './style';
 
-interface AccountSettingProps extends SelectsOptions {
+interface AccountSettingProps extends UserMutator, SelectsOptions {
   user: IUserInfo;
 }
+
 type RequiredFields = Pick<IUserInfo, 'username' | 'email'>;
 type OptionalFieldsValue = {
   skills: string[] | null;
@@ -30,6 +36,7 @@ type OptionalFieldsValue = {
 
 const AccountSetting = ({
   user: { id, skills, job, username, email },
+  mutateUser,
   skillOptions,
   jobOptions,
 }: AccountSettingProps) => {
@@ -91,10 +98,17 @@ const AccountSetting = ({
     watchedRequiredFields,
   ]);
 
-  const handleAccountDeleteButtonClick = () => {
-    alert('유저 삭제 미구현');
-    // TODO: 유저 삭제 요청 (DELETE))
+  const handleAccountDeleteButtonClick = async () => {
+    // TODO: 모달 추가 후 '정말로 삭제하시겠습니까?' 추가
+    try {
+      await deleteAccountApi(id);
+      mutateUser({ isLoggedIn: false });
+      token.delete();
+    } catch (err) {
+      logAxiosError(err as GeneralAxiosError);
+    }
   };
+
   const handleSaveButtonClick = () => {
     if (!isSubmittable()) return;
     hiddenSubmitButtonEl.current?.click();

--- a/next/src/components/my-page/AccountSetting/section/Email.tsx
+++ b/next/src/components/my-page/AccountSetting/section/Email.tsx
@@ -1,0 +1,41 @@
+import type { UseFormRegister, FormState } from 'react-hook-form';
+
+import InputWrapper from '@components/common/InputWrapper';
+import Label from '@components/common/Label';
+import Warning from '@components/common/Warning';
+import { emailRule } from '@lib/regex';
+
+import * as S from '../style';
+
+interface Email {
+  email: string;
+}
+interface Props {
+  register: UseFormRegister<Email>;
+  errors: FormState<Email>['errors'];
+}
+
+const EmailSection = ({ register, errors }: Props) => (
+  <>
+    <InputWrapper>
+      <Label htmlFor="email" direction="bottom">
+        이메일
+      </Label>
+      <S.Input
+        type="text"
+        id="email"
+        spellCheck="false"
+        {...register('email', {
+          pattern: {
+            value: emailRule,
+            message: '올바른 형식의 이메일을 입력해주세요.',
+          },
+          required: true,
+        })}
+      />
+    </InputWrapper>
+    {errors.email && <Warning>{errors.email.message}</Warning>}
+  </>
+);
+
+export default EmailSection;

--- a/next/src/components/my-page/AccountSetting/section/JobSelect.tsx
+++ b/next/src/components/my-page/AccountSetting/section/JobSelect.tsx
@@ -8,10 +8,11 @@ import Label from '@components/common/Label';
 interface JobSelectProps {
   options: SelectProps[];
   setId: React.Dispatch<React.SetStateAction<string | null>>;
+  defaultValue: SelectProps; // For use in my-page/account-setting
 }
 type Job = ValueType<SelectProps, false> | null;
 
-const JobSelect = ({ options, setId }: JobSelectProps) => {
+const JobSelect = ({ options, setId, defaultValue }: JobSelectProps) => {
   // react-select 에서 onChange 는 해당 Select 에서 선택되어 있는 현재 데이터를 반환합니다.
   const onChangeJob = (job: Job) => setId(job?.value || null);
 
@@ -28,6 +29,7 @@ const JobSelect = ({ options, setId }: JobSelectProps) => {
         onChange={(data) => {
           onChangeJob(data as Job);
         }}
+        defaultValue={defaultValue}
       />
     </InputWrapper>
   );

--- a/next/src/components/my-page/AccountSetting/section/SkillsSelect.tsx
+++ b/next/src/components/my-page/AccountSetting/section/SkillsSelect.tsx
@@ -8,13 +8,14 @@ import type { SelectProps } from '@components/common/Select';
 
 const SKILLS_LIMIT = 5;
 
-interface SkillsSelectProps {
+interface Props {
   options: SelectProps[];
   setIds: React.Dispatch<React.SetStateAction<string[] | null>>;
+  defaultValue: SelectProps[]; // For use in my-page/account-setting
 }
 type Skills = ValueType<SelectProps, true> | null;
 
-const SkillsSelect = ({ options, setIds }: SkillsSelectProps) => {
+const SkillsSelect = ({ options, setIds, defaultValue }: Props) => {
   const [isShowOptions, setIsShowOptions] = useState<boolean>(true);
 
   // react-select 에서 onChange 는 해당 Select 에서 선택되어 있는 현재 데이터를 반환합니다.
@@ -40,6 +41,7 @@ const SkillsSelect = ({ options, setIds }: SkillsSelectProps) => {
         onChange={(data) => {
           onChangeSkills(data as Skills);
         }}
+        defaultValue={defaultValue}
       />
     </InputWrapper>
   );

--- a/next/src/components/my-page/AccountSetting/section/SkillsSelect.tsx
+++ b/next/src/components/my-page/AccountSetting/section/SkillsSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import type { ValueType } from 'react-select';
 
 import Select from '@components/common/Select';

--- a/next/src/components/my-page/AccountSetting/section/SkillsSelect.tsx
+++ b/next/src/components/my-page/AccountSetting/section/SkillsSelect.tsx
@@ -11,7 +11,7 @@ const SKILLS_LIMIT = 5;
 interface Props {
   options: SelectProps[];
   setIds: React.Dispatch<React.SetStateAction<string[] | null>>;
-  defaultValue: SelectProps[]; // For use in my-page/account-setting
+  defaultValue: SelectProps[];
 }
 type Skills = ValueType<SelectProps, true> | null;
 

--- a/next/src/components/my-page/AccountSetting/section/Username.tsx
+++ b/next/src/components/my-page/AccountSetting/section/Username.tsx
@@ -1,0 +1,42 @@
+import type { UseFormRegister, FormState } from 'react-hook-form';
+
+import InputWrapper from '@components/common/InputWrapper';
+import Label from '@components/common/Label';
+import Warning from '@components/common/Warning';
+import { usernameRule } from '@lib/regex';
+
+import * as S from '../style';
+
+interface Username {
+  username: string;
+}
+interface Props {
+  register: UseFormRegister<Username>;
+  errors: FormState<Username>['errors'];
+}
+
+const UsernameSection = ({ register, errors }: Props) => (
+  <>
+    <InputWrapper>
+      <Label htmlFor="username" direction="bottom">
+        유저명
+      </Label>
+      <S.Input
+        type="text"
+        id="username"
+        spellCheck="false"
+        {...register('username', {
+          pattern: {
+            value: usernameRule,
+            message:
+              '규칙에 맞는 유저명을 입력해주세요 (영문/한글/숫자/마침표 1-12자).',
+          },
+          required: true,
+        })}
+      />
+    </InputWrapper>
+    {errors.username && <Warning>{errors.username.message}</Warning>}
+  </>
+);
+
+export default UsernameSection;

--- a/next/src/components/my-page/AccountSetting/style.tsx
+++ b/next/src/components/my-page/AccountSetting/style.tsx
@@ -4,6 +4,7 @@ import _Form from '@components/common/Form';
 import media from '@globalStyles/media';
 
 const FOOTER_HEIGHT = '5rem';
+const PARENT_BREAKPOINT = media.lg;
 
 export const Main = styled.main`
   grid-area: main;
@@ -21,8 +22,8 @@ export const MainTitle = styled.h1`
 
 export const Form = styled(_Form)`
   position: relative;
-  // my-page Container의 breakpoint에 맞춤
-  ${media.lg} {
+
+  ${PARENT_BREAKPOINT} {
     max-width: 30rem;
   }
 `;
@@ -67,10 +68,18 @@ export const Footer = styled.footer`
   position: fixed; // relative to <body>
   left: 0;
   bottom: 0;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
   padding-left: 1rem;
   padding-right: 1rem;
   background-color: var(--color-gray-0);
+
+  button {
+    position: absolute;
+    top: 50%;
+    left: calc(100% - 3.5rem);
+    transform: translate(-50%, -50%);
+
+    ${PARENT_BREAKPOINT} {
+      left: 66%;
+    }
+  }
 `;

--- a/next/src/components/sign-up/Optional/JobSelect.tsx
+++ b/next/src/components/sign-up/Optional/JobSelect.tsx
@@ -14,7 +14,7 @@ type Job = ValueType<SelectProps, false> | null;
 
 const JobSelect = ({ options, setId, defaultValue }: JobSelectProps) => {
   // react-select 에서 onChange 는 해당 Select 에서 선택되어 있는 현재 데이터를 반환합니다.
-  const onChangeJob = (job: Job) => setId(job?.label || null);
+  const onChangeJob = (job: Job) => setId(job?.value || null);
 
   return (
     <InputWrapper>

--- a/next/src/lib/apis.ts
+++ b/next/src/lib/apis.ts
@@ -8,7 +8,7 @@ import type {
   IAuthSuccessResponse,
   IGetChatRoomProps,
   IAccountEditProps,
-  IUserInfo,
+  IAccountEditResponse,
 } from 'typings/auth';
 import { IncomingHttpHeaders } from 'http';
 
@@ -55,7 +55,9 @@ export const authProlongTestApi = () =>
 // 유저 정보 수정
 // TODO: nest API 추가시 axios > apiClient로 변경하기
 export const editAccountApi = (data: IAccountEditProps) =>
-  axios.put<IUserInfo>(`/api/user`, data).then((res) => res.data);
+  axios
+    .put<IAccountEditResponse>(`/api/user`, data)
+    .then((res) => res.data.user);
 
 // 계정 삭제
 // TODO: nest API 추가시 axios > apiClient로 변경하기

--- a/next/src/lib/apis.ts
+++ b/next/src/lib/apis.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'; // temp
 import apiClient, { logAxiosError } from '@lib/apiClient';
 import type { IGeneralServerResponse } from 'typings/common';
 import type {
@@ -48,6 +49,11 @@ export const authProlongTestApi = () =>
     .catch(() => {
       window.alert('로그인 연장 실패, 로그를 확인해주세요.');
     });
+
+// 계정 삭제
+// TODO: nest API 추가시 axios > apiClient로 변경하기
+export const deleteAccountApi = (id: number) =>
+  axios.delete<IGeneralServerResponse>(`/api/user/${id}`);
 
 // ********************************************************************************************************************
 // sign-up

--- a/next/src/lib/apis.ts
+++ b/next/src/lib/apis.ts
@@ -7,6 +7,8 @@ import type {
   IOptionalPropsResponse,
   IAuthSuccessResponse,
   IGetChatRoomProps,
+  IAccountEditProps,
+  IUserInfo,
 } from 'typings/auth';
 import { IncomingHttpHeaders } from 'http';
 
@@ -49,6 +51,11 @@ export const authProlongTestApi = () =>
     .catch(() => {
       window.alert('로그인 연장 실패, 로그를 확인해주세요.');
     });
+
+// 유저 정보 수정
+// TODO: nest API 추가시 axios > apiClient로 변경하기
+export const editAccountApi = (data: IAccountEditProps) =>
+  axios.put<IUserInfo>(`/api/user`, data).then((res) => res.data);
 
 // 계정 삭제
 // TODO: nest API 추가시 axios > apiClient로 변경하기

--- a/next/src/lib/regex.ts
+++ b/next/src/lib/regex.ts
@@ -3,7 +3,7 @@ export const usernameRule = /^[^ㄱ-ㅎ]?[가-힣a-zA-Z0-9.]{1,12}$/;
 
 // email: 이메일
 export const emailRule =
-  /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+  /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
 
 // password: 비밀번호, 영문자, 숫자, 특수문자 각각 1개 이상 포함한 8-50자
 export const passwordRule =

--- a/next/src/lib/toSelectOptions.ts
+++ b/next/src/lib/toSelectOptions.ts
@@ -12,18 +12,19 @@ const toSelectOptions = (
   if (options === null) return [];
 
   if (!Array.isArray(options)) {
+    const { id, name } = options;
     return [
       {
-        value: options.id.toString(),
-        label: options.name,
+        label: name,
+        value: id.toString(),
       },
     ];
   }
 
   return options.map(
     ({ id, name }): SelectProps => ({
-      value: id.toString(),
       label: name,
+      value: id.toString(),
     }),
   );
 };

--- a/next/src/pages/api/user/[id].ts
+++ b/next/src/pages/api/user/[id].ts
@@ -15,9 +15,9 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
   console.log(`${id}번 계정을 가짜로 삭제하지롱`);
 
   res.setHeader('Set-Cookie', `${REFRESH_TOKEN}=; path=/; expires=-1`);
-  res.status(200).json({
+  res.status(204).json({
     message: '계정이 성공적으로 삭제되었습니다.',
-    statusCode: 200,
+    statusCode: 204,
   });
 };
 

--- a/next/src/pages/api/user/[id].ts
+++ b/next/src/pages/api/user/[id].ts
@@ -1,0 +1,24 @@
+import { REFRESH_TOKEN } from '@lib/token';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  const { id } = req.query;
+
+  if (req.method !== 'DELETE') {
+    res.status(405).json({
+      message: 'Method not allowed',
+      statusCode: 405,
+    });
+    return;
+  }
+
+  console.log(`${id}번 계정을 가짜로 삭제하지롱`);
+
+  res.setHeader('Set-Cookie', `${REFRESH_TOKEN}=; path=/; expires=-1`);
+  res.status(200).json({
+    message: '계정이 성공적으로 삭제되었습니다.',
+    statusCode: 200,
+  });
+};
+
+export default handler;

--- a/next/src/pages/api/user/index.ts
+++ b/next/src/pages/api/user/index.ts
@@ -16,9 +16,13 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
 
   const changedUser: IUserInfo = {
     id: 1,
-    email: 'changed@gmail.com',
-    username: 'changed',
+    email: 'mogakco35@gmail.com',
+    username: 'mogauser',
     skills: [
+      {
+        id: 1,
+        name: '리눅스',
+      },
       {
         id: 13,
         name: '풀스택',

--- a/next/src/pages/api/user/index.ts
+++ b/next/src/pages/api/user/index.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { IAccountEditProps, IUserInfo } from 'typings/auth';
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  const userInfo: IAccountEditProps = req.body;
+
+  if (req.method !== 'PUT') {
+    res.status(405).json({
+      message: 'Method not allowed',
+      statusCode: 405,
+    });
+    return;
+  }
+
+  console.log('다음 정보로 PUT 요청이 왔지롱', userInfo);
+
+  const changedUser: IUserInfo = {
+    id: 1,
+    email: 'changed@gmail.com',
+    username: 'changed',
+    skills: [
+      {
+        id: 13,
+        name: '풀스택',
+      },
+    ],
+    job: {
+      id: 8,
+      name: '보안 관제',
+    },
+  };
+
+  res.status(200).json({
+    message: '계정 정보가 성공적으로 수정되었습니다.',
+    statusCode: 200,
+    user: changedUser,
+  });
+};
+
+export default handler;

--- a/next/src/pages/my-page/account-setting.tsx
+++ b/next/src/pages/my-page/account-setting.tsx
@@ -18,8 +18,8 @@ export const pageProps = {
 };
 
 const MyPageAccountSetting = (props: SelectsOptions) => {
-  // const { user } = useUser({ redirectTo: '/' });
-  const { user } = useUser();
+  // const { user, mutateUser } = useUser({ redirectTo: '/' });
+  const { user, mutateUser } = useUser();
 
   if (!user?.isLoggedIn) return null;
   return (
@@ -28,7 +28,11 @@ const MyPageAccountSetting = (props: SelectsOptions) => {
       <ServiceHeader />
       <Container>
         <Aside />
-        <AccountSetting user={user as IUserInfo} {...props} />
+        <AccountSetting
+          user={user as IUserInfo}
+          mutateUser={mutateUser}
+          {...props}
+        />
       </Container>
     </>
   );

--- a/next/src/pages/my-page/account-setting.tsx
+++ b/next/src/pages/my-page/account-setting.tsx
@@ -18,8 +18,7 @@ export const pageProps = {
 };
 
 const MyPageAccountSetting = (props: SelectsOptions) => {
-  // const { user, mutateUser } = useUser({ redirectTo: '/' });
-  const { user, mutateUser } = useUser();
+  const { user, mutateUser } = useUser({ redirectTo: '/' });
 
   if (!user?.isLoggedIn) return null;
   return (

--- a/next/typings/auth.ts
+++ b/next/typings/auth.ts
@@ -20,6 +20,16 @@ export interface ISignUpProps {
 }
 
 /**
+ * 유저 정보 수정 요청 데이터 타입, 응답 데이터 타입
+ */
+export interface IAccountEditProps {
+  email: string;
+  username: string;
+  skills: number[] | null;
+  job: number | null;
+}
+
+/**
  * 회원가입/로그인/액세스토큰연장 성공 응답 스키마
  */
 export interface IAuthSuccessResponse extends IGeneralServerResponse {
@@ -52,8 +62,6 @@ export interface IUserGetResponse extends Partial<IUserInfo> {
 export interface IOptionalProps {
   id: number;
   name: string;
-  createdAt: Date;
-  updatedAt: Date;
 }
 export interface IOptionalPropsResponse extends IGeneralServerResponse {
   list: IOptionalProps[] | null;

--- a/next/typings/auth.ts
+++ b/next/typings/auth.ts
@@ -20,13 +20,20 @@ export interface ISignUpProps {
 }
 
 /**
- * 유저 정보 수정 요청 데이터 타입, 응답 데이터 타입
+ * 유저 정보 수정 요청 데이터 타입
  */
 export interface IAccountEditProps {
   email: string;
   username: string;
   skills: number[] | null;
   job: number | null;
+}
+
+/**
+ * 유저 정보 수정 요청 응답 데이터 타입
+ */
+export interface IAccountEditResponse extends IGeneralServerResponse {
+  user: IUserInfo;
 }
 
 /**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57123802/133866232-afc2ff9f-cf12-4569-ba79-8f2c190eee02.png)


## Nextjs api router에 설정한 가상 API 내용 _ next/src/pages/api/ 를 참고

### DELETE: /api/user/:id 200
user를 삭제합니다. 쿠키를 제거하고 성공응답을 보냅니다. 프런트측에선 성공응답 수신 후 토큰 정보를 삭제하고 user를 isLoggedin false 처리합니다.

### PUT: /api/user 204
user 정보를 덮어씁니다. password를 제외한 유저 정보 (id, username, email, skills, job) 가 req에 담깁니다. 해당 유저 정보를 덮어쓰고, 해당 덮어씌워져 변경된 유저의 정보를 반환합니다.
