### PR TITLE
feat: 어드민 및 어드민 전용 인증 구현

### DIFF
--- a/nest/src/authentication/auth.controller.ts
+++ b/nest/src/authentication/auth.controller.ts
@@ -33,6 +33,7 @@ import AuthService from './auth.service';
 
 import {
   AccessTokenSwagger,
+  AdminTestSwagger,
   BeforeRegisterSwagger,
   GetAuthenticationSwagger,
   LoginSwagger,
@@ -43,6 +44,7 @@ import {
 } from '@common/decorators/swagger/auth.decorator';
 import AuthValidateService from '@authentication/auth-validate.service';
 import NoUserException from '@common/exceptions/no-user-exception.filter';
+import AdminGuard from '@common/guards/admin.guard';
 
 /**
  * @desc 회원가입/로그인에 대한 처리 컨트롤러
@@ -61,6 +63,20 @@ export default class AuthController {
   ) {}
 
   /**
+   * @desc 어드민 테스트
+   */
+  @AdminTestSwagger()
+  @Get('/test/admin')
+  @UseGuards(AdminGuard)
+  @HttpCode(200)
+  adminTest(@Req() req: Request) {
+    return {
+      user: req.user,
+      message: '어드민 접근 성공입니다.',
+    };
+  }
+
+  /**
    * @returns 사용자 accessToken, 정보를 반환한다.
    */
   @Get('/test')
@@ -74,6 +90,7 @@ export default class AuthController {
   /**
    * @returns 로그인을 수행하고 로그인 정보를 반환합니다.
    */
+  // TODO: 로그인 상태에서 접근 막기
   @LoginSwagger()
   @Post('/login')
   @HttpCode(200)

--- a/nest/src/authentication/modules/jwt.module.ts
+++ b/nest/src/authentication/modules/jwt.module.ts
@@ -5,6 +5,7 @@ import { PassportModule } from '@nestjs/passport';
 import JwtStrategy from '@authentication/strategies/jwt.strategy';
 import JwtStrategyWithRefresh from '@authentication/strategies/jwt.refresh.strategy';
 import SharedModule from './shared.module';
+import JwtAdminStrategy from '@authentication/strategies/jwt-admin.strategy';
 
 /**
  * @desc jwt 인증에 관한 모듈입니다.
@@ -13,7 +14,7 @@ import SharedModule from './shared.module';
   imports: [
     forwardRef(() => SharedModule),
     PassportModule.register({
-      defaultStrategy: ['jwt', 'jwt-with-refresh'],
+      defaultStrategy: 'jwt',
     }),
     NestJwtModule.registerAsync({
       imports: [ConfigModule],
@@ -26,7 +27,7 @@ import SharedModule from './shared.module';
       }),
     }),
   ],
-  providers: [JwtStrategy, JwtStrategyWithRefresh],
-  exports: [JwtStrategy, JwtStrategyWithRefresh, PassportModule, NestJwtModule],
+  providers: [JwtStrategy, JwtStrategyWithRefresh, JwtAdminStrategy],
+  exports: [JwtStrategy, JwtStrategyWithRefresh, JwtAdminStrategy, PassportModule, NestJwtModule],
 })
 export default class JwtModule {}

--- a/nest/src/authentication/strategies/jwt-admin.strategy.ts
+++ b/nest/src/authentication/strategies/jwt-admin.strategy.ts
@@ -1,0 +1,46 @@
+import {
+  BadGatewayException,
+  Injectable,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { IJwtPayload } from '@typing/auth';
+import { getManager } from 'typeorm';
+import UserEntity from '@models/user/entities/user.entity';
+import UserRolesEntity from '@models/user/entities/user-roles.entity';
+
+@Injectable()
+export default class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
+  constructor(private configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: configService.get('JWT_ACCESS_TOKEN_SECRET'),
+      ignoreExpiration: false,
+    });
+  }
+
+  async validate({ id }: IJwtPayload) {
+    const user = await getManager().findOne(
+      UserEntity,
+      { id },
+      {
+        select: ['id', 'username'],
+      },
+    );
+    if (!user) throw new BadGatewayException('존재하지 않는 유저입니다.');
+    const userRole = await getManager().findOne(UserRolesEntity, {
+      where: {
+        user,
+      },
+      relations: ['role'],
+    });
+    if (!userRole) throw new InternalServerErrorException('사용자 권한이 존재하지 않습니다');
+    if (userRole.role.name === '관리자') {
+      return user;
+    }
+    throw new UnauthorizedException('어드민 권한이 없습니다.');
+  }
+}

--- a/nest/src/common/decorators/swagger/auth.decorator.ts
+++ b/nest/src/common/decorators/swagger/auth.decorator.ts
@@ -224,3 +224,14 @@ export function GetAuthenticationSwagger() {
     }),
   );
 }
+
+export function AdminTestSwagger() {
+  return decoratorHelper(
+    SwaggerTag.AUTH,
+    ApiOperation({
+      summary: '어드민 테스트 API',
+      description: '어드민이 접근 할 수 있는 지 테스트 합니다.',
+    }),
+    ApiBearerAuth(),
+  );
+}

--- a/nest/src/common/guards/admin.guard.ts
+++ b/nest/src/common/guards/admin.guard.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+/**
+ * @desc 어드민으로 접근하는 유저인 지 검사합니다.
+ */
+@Injectable()
+export default class AdminGuard extends AuthGuard('jwt-admin') {}

--- a/nest/src/common/guards/non-auth.guard.ts
+++ b/nest/src/common/guards/non-auth.guard.ts
@@ -1,6 +1,7 @@
-import { CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { GuardReturnType } from '@typing/auth';
 
+@Injectable()
 export default class NonAuthGuard implements CanActivate {
   canActivate(context: ExecutionContext): GuardReturnType {
     const request = context.switchToHttp().getRequest();

--- a/nest/src/database/seeders/a3-test-admin-user.ts
+++ b/nest/src/database/seeders/a3-test-admin-user.ts
@@ -1,0 +1,40 @@
+import { Factory, Seeder } from 'typeorm-seeding';
+import { Connection } from 'typeorm';
+import { ServerEnviroment } from '@common/helpers/enum.helper';
+import { getRandomFieldList, getRandomJob } from '@common/helpers/test.helper';
+import makeHashHelper from '@common/helpers/make-hash.helper';
+import UserRepository from '@models/user/repositories/user.repository';
+import RolesRepository from '@models/user/repositories/roles.repository';
+
+/**
+ * @desc 어드민 계정을 생성합니다.
+ */
+export default class TestAdminUserSeed implements Seeder {
+  async run(factory: Factory, connection: Connection): Promise<void> {
+    if (process.env.NODE_ENV === ServerEnviroment.DEV) {
+      const user = await connection
+        .getCustomRepository(UserRepository)
+        .create({
+          username: 'admin',
+          password: await makeHashHelper('admin'),
+          email: 'admin@admin.com',
+          skills: await getRandomFieldList(),
+          job: await getRandomJob(),
+        })
+        .save();
+
+      const role = await connection.getCustomRepository(RolesRepository).findOne({
+        where: { name: '관리자' },
+      });
+
+      await connection.query(
+        `
+        INSERT
+        INTO user_roles (user_id, role_id)
+        VALUES (?, ?);
+      `,
+        [user.id, role?.id],
+      );
+    }
+  }
+}

--- a/nest/src/models/user/entities/user-roles.entity.ts
+++ b/nest/src/models/user/entities/user-roles.entity.ts
@@ -21,5 +21,8 @@ export default class UserRolesEntity extends BaseEntitySoftDelete {
     nullable: false,
     onUpdate: 'CASCADE',
   })
-  role!: UserRolesEntity;
+  @JoinColumn({
+    name: 'role_id',
+  })
+  role!: RolesEntity;
 }


### PR DESCRIPTION
# Summary
* 테스트를 Swagger 로 만들었습니다. ( 어드민 권한 Api 가 현재 없어서 Swagger 로 작성함 )
> 테스트에 사용하고, 서비스에 사용하지 않을 Api 라 Swagger Response 가 없습니다.
> 현재 테스트 Api 는 추 후, 테스트 구간으로 따로 관리하도록 하겠습니다.
* 이제 어드민 기능이 생겼습니다. ( 기존 유저 테이블에서 생성 )
* 어드민만 권한을 허용하는 전략과 가드 시스템을 작성하였습니다.

# Admin Account
계정 admin@admin.com
비밀번호 admin

# You Must Do
`npm run seed:run`