### PR TITLE
feat: 익명 사용자에 대한 기능과 Api 추가

### DIFF
--- a/nest/src/common/decorators/swagger/chat.decorator.ts
+++ b/nest/src/common/decorators/swagger/chat.decorator.ts
@@ -1,6 +1,6 @@
 import decoratorHelper from '@common/helpers/decorator.helper';
 import { SwaggerTag } from '@common/helpers/enum.helper';
-import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { HttpStatus } from '@nestjs/common';
 
 export function ChatAvailableSwagger() {
@@ -93,6 +93,78 @@ export function JoinChatRoomSwagger() {
           message: 'Unauthorized',
         },
       },
+    }),
+  );
+}
+
+export function AddAnonymousPrefixSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 사용자 접두어 추가 API',
+      description: '15글자 이하 이름을 받아서 익명 사용자 이름에 부여되는 접두어를 추가합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiBody({
+      description: '15글자 이하의 이름',
+      schema: {
+        example: {
+          name: '안경을 박살낸',
+        },
+      },
+    }),
+    ApiResponse({
+      status: HttpStatus.OK,
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '익명 사용자 접두어 추가를 성공하였습니다.',
+        },
+      },
+    }),
+    ApiResponse({
+      status: HttpStatus.BAD_REQUEST,
+      description: '요청 양식이 잘못 됨',
+    }),
+    ApiResponse({
+      status: HttpStatus.UNAUTHORIZED,
+      description: '어드민 권한이 없음',
+    }),
+  );
+}
+
+export function AddAnonymousNameSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 사용자 이름 추가 API',
+      description: '15글자 이하 이름을 받아서 익명 사용자 이름에 부여되는 접두어를 추가합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiBody({
+      description: '15글자 이하의 이름',
+      schema: {
+        example: {
+          name: '호이스팅',
+        },
+      },
+    }),
+    ApiResponse({
+      status: HttpStatus.OK,
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '익명 사용자 이름 추가를 성공하였습니다.',
+        },
+      },
+    }),
+    ApiResponse({
+      status: HttpStatus.BAD_REQUEST,
+      description: '요청 양식이 잘못 됨',
+    }),
+    ApiResponse({
+      status: HttpStatus.UNAUTHORIZED,
+      description: '어드민 권한이 없음',
     }),
   );
 }

--- a/nest/src/database/seeders/a4-test-anonymous-props.ts
+++ b/nest/src/database/seeders/a4-test-anonymous-props.ts
@@ -1,0 +1,47 @@
+import { Factory, Seeder } from 'typeorm-seeding';
+import { Connection } from 'typeorm';
+import UserRepository from '@models/user/repositories/user.repository';
+import { ServerEnviroment } from '@common/helpers/enum.helper';
+import AnonymousPrefixEntity from '@models/chat/entities/anonymous_prefix.entity';
+import AnonymousNameEntity from '@models/chat/entities/anonymous_names.entity';
+
+export default class TestAnonymousPropSeed implements Seeder {
+  async run(factory: Factory, connection: Connection): Promise<void> {
+    if (process.env.NODE_ENV === ServerEnviroment.DEV) {
+      const testAdmin = await connection.getCustomRepository(UserRepository).findOne({
+        where: { username: 'admin' },
+      });
+      await connection
+        .createQueryBuilder()
+        .insert()
+        .into(AnonymousPrefixEntity)
+        .values([
+          {
+            name: '안경을 똑바로 쓴',
+            user: testAdmin,
+          },
+          {
+            name: '안경을 거꾸로 쓴',
+            user: testAdmin,
+          },
+        ])
+        .execute();
+
+      await connection
+        .createQueryBuilder()
+        .insert()
+        .into(AnonymousNameEntity)
+        .values([
+          {
+            name: '프로브',
+            user: testAdmin,
+          },
+          {
+            name: '김첨지',
+            user: testAdmin,
+          },
+        ])
+        .execute();
+    }
+  }
+}

--- a/nest/src/models/chat/dto/anonymous-prop.dto.ts
+++ b/nest/src/models/chat/dto/anonymous-prop.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export default class AnonymousPropDto {
+  @ApiProperty({ description: '이름' })
+  @IsString({ message: '문자열이 아닙니다.' })
+  @MinLength(2, { message: '이름의 길이가 너무 작습니다.' })
+  @MaxLength(15, { message: '이름의 길이가 너무 큽니다.' })
+  readonly name!: string;
+}

--- a/nest/src/models/chat/dto/anonymous-prop.dto.ts
+++ b/nest/src/models/chat/dto/anonymous-prop.dto.ts
@@ -5,6 +5,6 @@ export default class AnonymousPropDto {
   @ApiProperty({ description: '이름' })
   @IsString({ message: '문자열이 아닙니다.' })
   @MinLength(2, { message: '이름의 길이가 너무 작습니다.' })
-  @MaxLength(15, { message: '이름의 길이가 너무 큽니다.' })
+  @MaxLength(10, { message: '이름의 길이가 너무 큽니다.' })
   readonly name!: string;
 }

--- a/nest/src/models/chat/entities/anonymous_names.entity.ts
+++ b/nest/src/models/chat/entities/anonymous_names.entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntitySoftDelete } from '@common/helpers/entity.helper';
+import UserEntity from '@models/user/entities/user.entity';
+
+@Entity({
+  name: 'anonymous_names',
+})
+export default class AnonymousNameEntity extends BaseEntitySoftDelete {
+  @Column({ nullable: false, length: 15, unique: true })
+  name!: string;
+
+  @ManyToOne(() => UserEntity, user => user.anonymousNames)
+  @JoinColumn({ name: 'user_id' })
+  user!: UserEntity;
+}

--- a/nest/src/models/chat/entities/anonymous_names.entity.ts
+++ b/nest/src/models/chat/entities/anonymous_names.entity.ts
@@ -1,12 +1,12 @@
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
-import { BaseEntitySoftDelete } from '@common/helpers/entity.helper';
+import { BaseEntityHardDelete } from '@common/helpers/entity.helper';
 import UserEntity from '@models/user/entities/user.entity';
 
 @Entity({
   name: 'anonymous_names',
 })
-export default class AnonymousNameEntity extends BaseEntitySoftDelete {
-  @Column({ nullable: false, length: 15, unique: true })
+export default class AnonymousNameEntity extends BaseEntityHardDelete {
+  @Column({ nullable: false, length: 10, unique: true })
   name!: string;
 
   @ManyToOne(() => UserEntity, user => user.anonymousNames)

--- a/nest/src/models/chat/entities/anonymous_prefix.entity.ts
+++ b/nest/src/models/chat/entities/anonymous_prefix.entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntitySoftDelete } from '@common/helpers/entity.helper';
+import UserEntity from '@models/user/entities/user.entity';
+
+@Entity({
+  name: 'anonymous_prefix_names',
+})
+export default class AnonymousPrefixEntity extends BaseEntitySoftDelete {
+  @Column({ nullable: false, length: 15, unique: true })
+  name!: string;
+
+  @ManyToOne(() => UserEntity, user => user.anonymousUser)
+  @JoinColumn({ name: 'user_id' })
+  user!: UserEntity;
+}

--- a/nest/src/models/chat/entities/anonymous_prefix.entity.ts
+++ b/nest/src/models/chat/entities/anonymous_prefix.entity.ts
@@ -1,12 +1,12 @@
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
-import { BaseEntitySoftDelete } from '@common/helpers/entity.helper';
+import { BaseEntityHardDelete } from '@common/helpers/entity.helper';
 import UserEntity from '@models/user/entities/user.entity';
 
 @Entity({
   name: 'anonymous_prefix_names',
 })
-export default class AnonymousPrefixEntity extends BaseEntitySoftDelete {
-  @Column({ nullable: false, length: 15, unique: true })
+export default class AnonymousPrefixEntity extends BaseEntityHardDelete {
+  @Column({ nullable: false, length: 10, unique: true })
   name!: string;
 
   @ManyToOne(() => UserEntity, user => user.anonymousUser)

--- a/nest/src/models/chat/interface/controller.ts
+++ b/nest/src/models/chat/interface/controller.ts
@@ -1,4 +1,7 @@
 import { Request, Response } from 'express';
+import { AuthRequest } from '@models/user/interface/controller';
+import { GeneralResponse } from '@common/interface/global';
+import AnonymousPropDto from '@models/chat/dto/anonymous-prop.dto';
 
 export interface AvailableRoom {
   message: string;
@@ -21,4 +24,18 @@ export interface IChatController {
   getMembers(roomId: number): Promise<MemberCount>;
 
   join(req: Request, res: Response): Promise<ChatRoomJoin | Pick<ChatRoomJoin, 'message'>>;
+
+  chatFileUpload(file: Express.Multer.File): Promise<any>;
+
+  chatFileDownload(req: Request): any;
+
+  addAnonymousPrefixRuleByAdmin(
+    req: AuthRequest,
+    prefixBody: AnonymousPropDto,
+  ): Promise<GeneralResponse>;
+
+  addAnonymousNameRuleByAdmin(
+    req: AuthRequest,
+    prefixBody: AnonymousPropDto,
+  ): Promise<GeneralResponse>;
 }

--- a/nest/src/models/chat/interface/service.ts
+++ b/nest/src/models/chat/interface/service.ts
@@ -32,6 +32,11 @@ export interface FindRoomAndJoin {
 
 export type AuthProp = string | undefined;
 
+export interface InfoFromHeader {
+  userId: number;
+  roomId: number;
+}
+
 export interface IChatService {
   getRecommendRoom(id: number): Promise<RoomEntity | FindRoomAndJoin>;
 
@@ -51,7 +56,9 @@ export interface IChatService {
 
   emitEnterOrExitEvent(server: Server, username: string, type: 'enter' | 'exit'): void;
 
-  getIdsFromHeader(headers: IncomingHttpHeaders): number[];
+  getInfoFromHeader(auth: HandShakeAuth): InfoFromHeader;
 
-  validateAuth(auth: HandShakeAuth): boolean;
+  addAnonymousPrefixName(adminId: number, name: string): Promise<void>;
+
+  addAnonymousName(adminId: number, name: string): Promise<void>;
 }

--- a/nest/src/models/user/entities/user.entity.ts
+++ b/nest/src/models/user/entities/user.entity.ts
@@ -5,11 +5,13 @@ import RoomUserEntity from '@models/chat/entities/room-user.entity';
 import UserJobEntity from './users-job.entity';
 import AnonymousRoomUserEntity from '@models/chat/entities/anonymous-room-user.entity';
 import RoomEntity from '@models/chat/entities/room.entity';
+import AnonymousPrefixEntity from '@models/chat/entities/anonymous_prefix.entity';
+import AnonymousNameEntity from '@models/chat/entities/anonymous_names.entity';
 
 @Entity({
   name: 'users',
 })
-class UserEntity extends BaseEntitySoftDelete {
+export default class UserEntity extends BaseEntitySoftDelete {
   @Column({ nullable: false, length: 10 })
   username!: string;
 
@@ -39,6 +41,10 @@ class UserEntity extends BaseEntitySoftDelete {
 
   @OneToMany(() => RoomEntity, room => room.ownerId)
   room!: RoomEntity[];
-}
 
-export default UserEntity;
+  @OneToMany(() => AnonymousPrefixEntity, prefix => prefix.user)
+  prefixNames!: AnonymousPrefixEntity[];
+
+  @OneToMany(() => AnonymousNameEntity, prefix => prefix.user)
+  anonymousNames!: AnonymousNameEntity[];
+}

--- a/nest/test/e2e/helper/enum.ts
+++ b/nest/test/e2e/helper/enum.ts
@@ -15,10 +15,18 @@ export enum APIs {
   // User
   UPDATE_USER_SELF = '/api/user',
   DELETE_USER_SELF = '/api/user',
+
+  // Chat
+  ADD_ANONYMOUS_PREFIX_NAME = '/api/chat/anonymous/prefix-name',
+  ADD_ANONYMOUS_NAME = '/api/chat/anonymous/name',
 }
 
 export enum TestUtil {
   EMAIL = 'mocktest@test.com',
   USERNAME = 'testuser',
   PASSWORD = '@Testmo12',
+
+  ADMIN_EMAIL = 'admin@admin.com',
+  ADMIN_USERNAME = 'admin',
+  ADMIN_PASSWORD = 'admin',
 }

--- a/next/src/hooks/useSocket.tsx
+++ b/next/src/hooks/useSocket.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import useUser from '@hooks/useUser';
 import { useRouter } from 'next/router';
 import { getServerUrl } from '@lib/enviroment';
+import token, { ACCESS_TOKEN } from '@lib/token';
 
 export default function useSocket() {
   const [socket, setSocket] = useState<Socket | null>(null);
@@ -13,9 +14,12 @@ export default function useSocket() {
     const uri = `${getServerUrl()}/chat`;
     const client = io(uri, {
       auth: {
-        'user-id': user?.id,
-        'room-id': query.id,
-        'user-name': user?.username,
+        userId: user?.id,
+        roomId: query.id,
+        userName: user?.username,
+      },
+      extraHeaders: {
+        Authorization: `Bearer ${token.get()[ACCESS_TOKEN]}`,
       },
     });
     setSocket(client);


### PR DESCRIPTION
# Summary
* 채팅방 익명 사용자에 대한 데이터를 이제 DB 모델에서 랜덤으로 가져오는 방식으로 변경하였습니다.
* 어드민의 권한으로 익명 사용자 이름 정보에 대한 데이터를 추가할 수 있습니다.
* 채팅 업로드에 대한 인터페이스 초안이 작성되어 있습니다.

# Apis
![image](https://user-images.githubusercontent.com/50310464/134433875-d3d2e542-b0f6-458d-9f9d-b73d50f845ea.png)
