### PR TITLE
feat: 익명에 관한 Api 목록 작성

### DIFF
--- a/nest/src/common/decorators/swagger/chat.decorator.ts
+++ b/nest/src/common/decorators/swagger/chat.decorator.ts
@@ -1,7 +1,26 @@
 import decoratorHelper from '@common/helpers/decorator.helper';
 import { SwaggerTag } from '@common/helpers/enum.helper';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
-import { HttpStatus } from '@nestjs/common';
+import { HttpStatus, applyDecorators } from '@nestjs/common';
+
+function errorResHelper() {
+  return applyDecorators(
+    ApiResponse({
+      status: HttpStatus.BAD_REQUEST,
+      description: '요청 양식이 잘못 됨',
+    }),
+    ApiResponse({
+      status: HttpStatus.UNAUTHORIZED,
+      description: '인증 권한이 없음',
+      schema: {
+        example: {
+          statusCode: HttpStatus.UNAUTHORIZED,
+          message: 'Unauthorized',
+        },
+      },
+    }),
+  );
+}
 
 export function ChatAvailableSwagger() {
   return decoratorHelper(
@@ -122,14 +141,7 @@ export function AddAnonymousPrefixSwagger() {
         },
       },
     }),
-    ApiResponse({
-      status: HttpStatus.BAD_REQUEST,
-      description: '요청 양식이 잘못 됨',
-    }),
-    ApiResponse({
-      status: HttpStatus.UNAUTHORIZED,
-      description: '어드민 권한이 없음',
-    }),
+    errorResHelper(),
   );
 }
 
@@ -158,13 +170,164 @@ export function AddAnonymousNameSwagger() {
         },
       },
     }),
-    ApiResponse({
-      status: HttpStatus.BAD_REQUEST,
-      description: '요청 양식이 잘못 됨',
+    errorResHelper(),
+  );
+}
+
+export function ModifyAnonymousPrefixSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 이름 접두어 수정 API',
+      description: '익명 이름의 아이디와 변경 이름을 받아 수정합니다.',
     }),
+    ApiBearerAuth(),
     ApiResponse({
-      status: HttpStatus.UNAUTHORIZED,
-      description: '어드민 권한이 없음',
+      status: HttpStatus.OK,
+      description: '변경 성공',
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '1번 데이터를 한번지린 으로 성공적으로 변경하였습니다.',
+          name: '한번지린',
+          id: 1,
+        },
+      },
     }),
+    errorResHelper(),
+  );
+}
+
+export function DeleteAnonymousPrefixSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 이름 접두어 삭제 API',
+      description: 'id 를 받아서 접두어를 삭제 처리합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiResponse({
+      status: HttpStatus.OK,
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '1번 데이터가 성공적으로 삭제되었습니다.',
+          id: 1,
+        },
+      },
+    }),
+    errorResHelper(),
+  );
+}
+
+export function ModifyAnonymousNameSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 이름 수정 API',
+      description: '아이디와 이름을 받아서 해당 아이디의 익명 이름을 수정합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiResponse({
+      status: HttpStatus.OK,
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '1번 데이터를 프런트준재 으로 성공적으로 변경하였습니다.',
+          name: '프런트준재',
+          id: 1,
+        },
+      },
+    }),
+    errorResHelper(),
+  );
+}
+export function DeleteAnonymousNameSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 이름 삭제 API',
+      description: '아이디를 받아 해당 아이디 정보의 익명 이름을 삭제합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiResponse({
+      status: HttpStatus.OK,
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '1번 데이터가 성공적으로 삭제되었습니다.',
+          id: 1,
+        },
+      },
+    }),
+    errorResHelper(),
+  );
+}
+
+export function FindAllAnonymousPrefixSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 접두어 이름 불러오기 API',
+    }),
+    ApiBearerAuth(),
+    ApiResponse({
+      status: HttpStatus.OK,
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '익명 접두어 목록을 성공적으로 불러왔습니다.',
+          list: [
+            {
+              id: 1,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              name: '황당한',
+            },
+            {
+              id: 2,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              name: '안경이 박살난',
+            },
+          ],
+        },
+      },
+    }),
+    errorResHelper(),
+  );
+}
+
+export function FindAllAnonymousNameSwagger() {
+  return decoratorHelper(
+    SwaggerTag.CHAT,
+    ApiOperation({
+      summary: '익명 이름 불러오기 API',
+    }),
+    ApiBearerAuth(),
+    ApiResponse({
+      status: HttpStatus.OK,
+      schema: {
+        example: {
+          statusCode: HttpStatus.OK,
+          message: '익명 이름 목록을 성공적으로 불러왔습니다.',
+          list: [
+            {
+              id: 1,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              name: '어피치',
+            },
+            {
+              id: 2,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              name: '제이지',
+            },
+          ],
+        },
+      },
+    }),
+    errorResHelper(),
   );
 }

--- a/nest/src/models/chat/chat.gateway.ts
+++ b/nest/src/models/chat/chat.gateway.ts
@@ -8,19 +8,17 @@ import {
   MessageBody,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Logger, UnauthorizedException, UseGuards } from '@nestjs/common';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 
 import ChatService from './chat.service';
 import UserRepository from '@models/user/repositories/user.repository';
 import { IChatGateway } from '@models/chat/interface/gateway';
 import AnonymousRoomUserRepository from '@models/chat/repositories/anonymous-room-user.repository';
-import JwtAuthGuard from '@common/guards/jwt-auth.guard';
 
 @WebSocketGateway({
   namespace: 'chat',
   cors: { origin: '*', credentials: true },
 })
-@UseGuards(JwtAuthGuard)
 export default class ChatGateway implements IChatGateway, OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server!: Server;

--- a/nest/src/models/chat/chat.service.ts
+++ b/nest/src/models/chat/chat.service.ts
@@ -207,6 +207,19 @@ export default class ChatService implements IChatService {
       .save();
   }
 
+  async modifyAnonymousPrefixName(id: number, name: string): Promise<void> {
+    await getRepository(AnonymousPrefixEntity).update(
+      { id },
+      {
+        name,
+      },
+    );
+  }
+
+  async deleteAnonymousPrefixName(id: number): Promise<void> {
+    await getRepository(AnonymousPrefixEntity).delete({ id });
+  }
+
   /**
    * @desc 익명 사용자 이름을 추가합니다.
    */
@@ -218,5 +231,25 @@ export default class ChatService implements IChatService {
         user: admin,
       })
       .save();
+  }
+
+  async modifyAnonymousName(id: number, name: string): Promise<void> {
+    await getRepository(AnonymousNameEntity).update({ id }, { name });
+  }
+
+  async deleteAnonymousName(id: number): Promise<void> {
+    await getRepository(AnonymousNameEntity).delete({ id });
+  }
+
+  async findAllAnonymousName(): Promise<AnonymousNameEntity[] | null> {
+    const list = await getRepository(AnonymousNameEntity).find();
+    if (!list) return null;
+    return list;
+  }
+
+  async findAllAnonymousPrefix(): Promise<AnonymousPrefixEntity[] | null> {
+    const list = await getRepository(AnonymousPrefixEntity).find();
+    if (!list) return null;
+    return list;
   }
 }

--- a/nest/src/models/chat/interface/controller.ts
+++ b/nest/src/models/chat/interface/controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { AuthRequest } from '@models/user/interface/controller';
 import { GeneralResponse } from '@common/interface/global';
 import AnonymousPropDto from '@models/chat/dto/anonymous-prop.dto';
+import AnonymousPrefixEntity from '@models/chat/entities/anonymous_prefix.entity';
 
 export interface AvailableRoom {
   message: string;
@@ -18,6 +19,19 @@ export interface ChatRoomJoin {
   message: string;
 }
 
+export interface UpdateAnonymousProp extends GeneralResponse {
+  id: number;
+  name: string;
+}
+
+export interface DeleteAnonymousProp extends GeneralResponse {
+  id: number;
+}
+
+export interface FindAllAnonymousProp extends GeneralResponse {
+  list: AnonymousPrefixEntity[] | null;
+}
+
 export interface IChatController {
   isAvailableChatRoom(roomId: number): Promise<AvailableRoom>;
 
@@ -26,16 +40,28 @@ export interface IChatController {
   join(req: Request, res: Response): Promise<ChatRoomJoin | Pick<ChatRoomJoin, 'message'>>;
 
   chatFileUpload(file: Express.Multer.File): Promise<any>;
-
   chatFileDownload(req: Request): any;
 
   addAnonymousPrefixRuleByAdmin(
     req: AuthRequest,
     prefixBody: AnonymousPropDto,
   ): Promise<GeneralResponse>;
+  modifyAnonymousPrefixRuleByAdmin(
+    id: number,
+    body: AnonymousPropDto,
+  ): Promise<UpdateAnonymousProp>;
+  deleteAnonymousPrefixRuleByAdmin(id: number): Promise<DeleteAnonymousProp>;
 
   addAnonymousNameRuleByAdmin(
     req: AuthRequest,
     prefixBody: AnonymousPropDto,
   ): Promise<GeneralResponse>;
+  modifyAnonymousPrefixNameByAdmin(
+    id: number,
+    body: AnonymousPropDto,
+  ): Promise<UpdateAnonymousProp>;
+  deleteAnonymousNameRuleByAdmin(id: number): Promise<DeleteAnonymousProp>;
+
+  findAllAnonymousPrefixRuleByAdmin(): Promise<FindAllAnonymousProp>;
+  findAllAnonymousNameRuleByAdmin(): Promise<FindAllAnonymousProp>;
 }

--- a/nest/src/models/chat/interface/service.ts
+++ b/nest/src/models/chat/interface/service.ts
@@ -2,6 +2,8 @@ import { IncomingHttpHeaders } from 'http';
 import UserEntity from '@models/user/entities/user.entity';
 import RoomEntity from '@models/chat/entities/room.entity';
 import { Server } from 'socket.io';
+import AnonymousPrefixEntity from '@models/chat/entities/anonymous_prefix.entity';
+import AnonymousNameEntity from '@models/chat/entities/anonymous_names.entity';
 
 export interface LeaveRoom {
   username: string;
@@ -59,6 +61,13 @@ export interface IChatService {
   getInfoFromHeader(auth: HandShakeAuth): InfoFromHeader;
 
   addAnonymousPrefixName(adminId: number, name: string): Promise<void>;
+  modifyAnonymousPrefixName(id: number, name: string): Promise<void>;
+  deleteAnonymousPrefixName(id: number): Promise<void>;
 
   addAnonymousName(adminId: number, name: string): Promise<void>;
+  modifyAnonymousName(id: number, name: string): Promise<void>;
+  deleteAnonymousName(id: number): Promise<void>;
+
+  findAllAnonymousPrefix(): Promise<AnonymousPrefixEntity[] | null>;
+  findAllAnonymousName(): Promise<AnonymousNameEntity[] | null>;
 }


### PR DESCRIPTION
# Summary
* 구현 Api 에 자세한 정보는 Swagger 확인해주세요.
* 익명 접두어에 관한 업데이트, 삭제, 전체 불러오기 추가
* 익명 이름에 대한 업데이트, 삭제, 전체 불러오기 추가
* 구현 된 모든 Api 는 관리자 권한 접근을 필요로 합니다.
* 총 8개의 api 항목
# Picture
![image](https://user-images.githubusercontent.com/50310464/134509584-ff246567-d12d-42f9-89e9-fc3126556e54.png)
