### PR TITLE
feat: 채팅 추가 시 스크롤 bottom으로 가도록 추가

### DIFF
--- a/next/src/components/video-chat/ChatSection/ChatList/index.tsx
+++ b/next/src/components/video-chat/ChatSection/ChatList/index.tsx
@@ -37,8 +37,15 @@ const ChatList = () => {
 
     const scrollToBottom = () => {
       if (!chatListRef.current) return;
+
       const chatListEl = chatListRef.current;
-      chatListEl.scrollTop = chatListEl.scrollHeight;
+      const { scrollHeight, clientHeight, scrollTop } = chatListEl;
+
+      const scrollTopMaxPixel = scrollHeight - clientHeight;
+      const isScrollAtNearlyEnd = scrollTop > scrollTopMaxPixel - clientHeight;
+      if (!isScrollAtNearlyEnd) return;
+
+      chatListEl.scrollTop = scrollTopMaxPixel;
     };
 
     const handleAddMessage = (newMessage: Message) => {


### PR DESCRIPTION
채팅 추가 시 기본적으론 스크롤 뷰를 제일 아래로 (방금 추가된 채팅으로) 이동하되, 채팅 상단부를 되돌아보려고 일부러 위로 스크롤한 경우엔 채팅이 추가되어도 스크롤 맨 아래로 뷰가 이동하지 않도록 설정했습니다.