### PR TITLE
fix: 서비스 페이지에서 useUser 요청 도중 user가 undefined일때 나타나는 랜딩페이지 flash fix

### DIFF
--- a/next/src/pages/index.tsx
+++ b/next/src/pages/index.tsx
@@ -24,7 +24,8 @@ const Landing = () => {
 
   const emailEl = useRef<HTMLInputElement>(null);
 
-  if (user?.isLoggedIn) return null;
+  if (user === undefined) return null;
+  if (user.isLoggedIn) return null;
   return (
     <>
       <CustomHead {...pageProps} />


### PR DESCRIPTION
서비스 페이지에 있다가 user 정보가 없어져 랜딩으로 리디렉션 될 경우 발생하는 flash 제거.  (예를 들면, 사용자가 서비스 페이지에 있다가 탭을 나갔다 와서 user정보가 말소되어, 랜딩 페이지로 리디렉션 되고 useUser 요청을 다시 보내서 응답이 올 때까지의 공백동안 발생하는 flash. 프런트 개발 도중 핫리로딩 시 발생하니 자주 보셨을겁니다)

랜딩페이지 첫 로딩은 느려보이겠지만, flash 보단 낫다고 판단했습니다.