### PR TITLE
feat: 입력한 채팅에 대한 링크 자동변환과 preview 기능 추가

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -2034,6 +2034,14 @@
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
       "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ=="
     },
+    "@dhaiwat10/react-link-preview": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@dhaiwat10/react-link-preview/-/react-link-preview-1.9.0.tgz",
+      "integrity": "sha512-wI6fLdD3mG4Z8mE/4bZpJfBybc5bPItfXNqWiLUVg5xj85jgbGMV5QmlMdqUFgYrJUGL7hNMiluGEx+kmuBNkA==",
+      "requires": {
+        "react-loading-skeleton": "^2.2.0"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
@@ -2101,7 +2109,6 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
       "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "dev": true,
       "requires": {
         "@emotion/serialize": "^0.11.15",
         "@emotion/utils": "0.11.3",
@@ -2111,14 +2118,12 @@
         "@emotion/memoize": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-          "dev": true
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
         },
         "@emotion/serialize": {
           "version": "0.11.16",
           "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
           "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-          "dev": true,
           "requires": {
             "@emotion/hash": "0.8.0",
             "@emotion/memoize": "0.7.4",
@@ -2130,14 +2135,12 @@
         "@emotion/utils": {
           "version": "0.11.3",
           "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-          "dev": true
+          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
         },
         "csstype": {
           "version": "2.6.18",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
-          "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==",
-          "dev": true
+          "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
         }
       }
     },
@@ -2265,8 +2268,7 @@
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
     },
     "@emotion/unitless": {
       "version": "0.7.5",
@@ -7017,7 +7019,6 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
       "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -7034,14 +7035,12 @@
         "@emotion/memoize": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-          "dev": true
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
         },
         "@emotion/serialize": {
           "version": "0.11.16",
           "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
           "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-          "dev": true,
           "requires": {
             "@emotion/hash": "0.8.0",
             "@emotion/memoize": "0.7.4",
@@ -7053,20 +7052,17 @@
         "@emotion/utils": {
           "version": "0.11.3",
           "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-          "dev": true
+          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
         },
         "csstype": {
           "version": "2.6.18",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
-          "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==",
-          "dev": true
+          "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         }
       }
     },
@@ -7190,8 +7186,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "backo2": {
       "version": "1.0.2",
@@ -14055,6 +14050,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
+    "linkifyjs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-3.0.1.tgz",
+      "integrity": "sha512-HwXVwdNH1wESBfo2sH7Bkl+ywzbGA3+uJEfhquCyi/bMCa49bFUvd/re1NT1Lox/5jdnpQXzI9O/jykit71idg=="
+    },
     "lint-staged": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.1.2.tgz",
@@ -18021,6 +18021,72 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
+    },
+    "react-loading-skeleton": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-2.2.0.tgz",
+      "integrity": "sha512-HH37uj9aobrUJSqFglHqO9KQt5zGQe+Svutv8LIq7Iq6gpJqCwIzJOsEVfkQy7ReirbI2uLhCtKloBGQIDP0BQ==",
+      "requires": {
+        "@emotion/core": "^10.0.22"
+      },
+      "dependencies": {
+        "@emotion/cache": {
+          "version": "10.0.29",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+          "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+          "requires": {
+            "@emotion/sheet": "0.9.4",
+            "@emotion/stylis": "0.8.5",
+            "@emotion/utils": "0.11.3",
+            "@emotion/weak-memoize": "0.2.5"
+          }
+        },
+        "@emotion/core": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+          "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "@emotion/cache": "^10.0.27",
+            "@emotion/css": "^10.0.27",
+            "@emotion/serialize": "^0.11.15",
+            "@emotion/sheet": "0.9.4",
+            "@emotion/utils": "0.11.3"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+        },
+        "@emotion/serialize": {
+          "version": "0.11.16",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+          "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+          "requires": {
+            "@emotion/hash": "0.8.0",
+            "@emotion/memoize": "0.7.4",
+            "@emotion/unitless": "0.7.5",
+            "@emotion/utils": "0.11.3",
+            "csstype": "^2.5.7"
+          }
+        },
+        "@emotion/sheet": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+          "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+        },
+        "@emotion/utils": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+        },
+        "csstype": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
+          "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
+        }
+      }
     },
     "react-popper": {
       "version": "2.2.5",

--- a/next/package.json
+++ b/next/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^1.6.7",
+    "@dhaiwat10/react-link-preview": "^1.9.0",
     "@emotion/babel-plugin": "^11.3.0",
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.4.1",
@@ -33,6 +34,7 @@
     "@toast-ui/react-editor": "^3.1.0",
     "axios": "^0.21.3",
     "framer-motion": "^4.1.17",
+    "linkifyjs": "^3.0.1",
     "lodash": "^4.17.21",
     "loglevel": "^1.7.1",
     "next": "^11.1.2",

--- a/next/src/components/video-chat/ChatSection/Chat/Message.tsx
+++ b/next/src/components/video-chat/ChatSection/Chat/Message.tsx
@@ -1,4 +1,9 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
+import _ from 'lodash';
+import * as linkify from 'linkifyjs';
+import { LinkPreview } from '@dhaiwat10/react-link-preview';
+import type { LinkPreviewProps } from '@dhaiwat10/react-link-preview';
+
 import useUser from '@hooks/useUser';
 import type { ChatMessage } from 'typings/chat';
 
@@ -9,10 +14,38 @@ const Message = ({ username, message, ownerId }: ChatMessage) => {
   const { user } = useUser();
   const MdViewer = useContext(MdViewerContext);
 
+  const getUniqueLinks = useCallback((plainText: string) => {
+    const hasProtocol = (url: string) => /(?:https?:\/\/).+/.test(url);
+
+    const linksWithProtocol = linkify
+      .find(plainText)
+      .filter(({ type, value }) => type === 'url' && hasProtocol(value));
+    const uniqueLinks = _.uniqBy(linksWithProtocol, ({ value }) =>
+      value.replace(/^www\./, ''),
+    );
+
+    return uniqueLinks.map(({ href }) => href);
+  }, []);
+
   return (
     <S.MessageWrapper>
       <S.Writer isMyChat={ownerId === user?.id}>{username}</S.Writer>
       <MdViewer initialValue={message} extendedAutolinks />
+      <ul>
+        {getUniqueLinks(message).map((link) => (
+          <li key={link}>
+            <LinkPreview
+              url={link}
+              width="100%"
+              imageHeight="9rem"
+              margin="0 0 0.66rem 0"
+              descriptionLength={100}
+              primaryTextColor="#21262d"
+              secondaryTextColor="#6e7681"
+            />
+          </li>
+        ))}
+      </ul>
     </S.MessageWrapper>
   );
 };

--- a/next/src/components/video-chat/ChatSection/Chat/Message.tsx
+++ b/next/src/components/video-chat/ChatSection/Chat/Message.tsx
@@ -12,7 +12,7 @@ const Message = ({ username, message, ownerId }: ChatMessage) => {
   return (
     <S.MessageWrapper>
       <S.Writer isMyChat={ownerId === user?.id}>{username}</S.Writer>
-      <MdViewer initialValue={message} />
+      <MdViewer initialValue={message} extendedAutolinks />
     </S.MessageWrapper>
   );
 };

--- a/next/src/components/video-chat/ChatSection/Chat/Message.tsx
+++ b/next/src/components/video-chat/ChatSection/Chat/Message.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useContext } from 'react';
 import _ from 'lodash';
 import * as linkify from 'linkifyjs';
 import { LinkPreview } from '@dhaiwat10/react-link-preview';
-import type { LinkPreviewProps } from '@dhaiwat10/react-link-preview';
 
 import useUser from '@hooks/useUser';
 import type { ChatMessage } from 'typings/chat';


### PR DESCRIPTION
링크 자동 변환은 왜 에디터에 기능 있을거라곤 생각을 못했지; 어제 삽질했네요

![image](https://user-images.githubusercontent.com/57123802/135510007-fca024ea-9c5f-4d80-8227-e0f4f3af7a42.png)

---
# Summary
* 링크 자동 변환 기능 추가
  * http/ https 혹은 'www'로 시작해야 링크 자동 변환이 지원됩니다.
    * naver.com (x) 
    * www.naver.com (o)
    * http://naver.com (o)
    * http://www.naver.com (o)
* 링크 preview 기능 추가
  * http/ https 가 붙어있어야 preview가 동작하게 했습니다. (슬랙 참고함)
    * naver.com (x) 
    * www.naver.com (x)
    * http://naver.com (o)
    * https://www.naver.com (o)
  * 한 텍스트 내의 중복 링크는 개중 하나만 띄웁니다.
    * `'이것은 네이버 링크들 > http://naver.com https://naver.com https://www.naver.com'`  => 셋 중 하나만 띄웁니다. markdown 문법으로 링크를 `[https://naver.com](https://naver.com)` 이렇게 써도 중복 제거해준단 소리
* 설치된 라이브러리
  * linkify: 주어진 plain 텍스트에서 링크 패턴을 모두 찾아줌
  * @dhaiwat10/react-link-preview: 리액트 링크 preview 라이브러리. 스켈레톤 로딩 지원