### PR TITLE
refactor: 채팅 서비스 Responsibility Driven Design 기반 리팩터링

### DIFF
--- a/nest/src/models/chat/chat.controller.ts
+++ b/nest/src/models/chat/chat.controller.ts
@@ -17,7 +17,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import ChatService from './chat.service';
+import ChatService from './services/chat.service';
 import {
   AddAnonymousNameSwagger,
   AddAnonymousPrefixSwagger,
@@ -51,6 +51,7 @@ import { AuthRequest } from '@models/user/interface/controller';
 import { GeneralResponse } from '@common/interface/global';
 import AnonymousPropDto from '@models/chat/dto/anonymous-prop.dto';
 import AdminGuard from '@common/guards/admin.guard';
+import ChatAnonymousService from './services/anonymous.service';
 
 @Controller('chat')
 export default class ChatController implements IChatController {
@@ -58,6 +59,7 @@ export default class ChatController implements IChatController {
 
   constructor(
     private readonly chatService: ChatService,
+    private readonly anonymousService: ChatAnonymousService,
     private readonly userService: UserService,
     private readonly roomRepository: RoomRepository,
     private readonly roomUserRepository: RoomUserRepository,
@@ -152,7 +154,7 @@ export default class ChatController implements IChatController {
     @Req() { user: { id: adminId } }: AuthRequest,
     @Body() { name }: AnonymousPropDto,
   ): Promise<GeneralResponse> {
-    await this.chatService.addAnonymousPrefixName(adminId, name);
+    await this.anonymousService.addAnonymousPrefixName(adminId, name);
     return {
       statusCode: HttpStatus.OK,
       message: '익명 사용자 접두어 추가를 성공하였습니다.',
@@ -169,7 +171,7 @@ export default class ChatController implements IChatController {
     @Param('id', new ParseIntPipe()) id: number,
     @Body() { name }: AnonymousPropDto,
   ): Promise<UpdateAnonymousProp> {
-    await this.chatService.modifyAnonymousPrefixName(id, name);
+    await this.anonymousService.modifyAnonymousPrefixName(id, name);
     return {
       statusCode: HttpStatus.OK,
       message: `${id} 번 데이터를 ${name} 으로 성공적으로 변경하였습니다.`,
@@ -187,7 +189,7 @@ export default class ChatController implements IChatController {
   async deleteAnonymousPrefixRuleByAdmin(
     @Param('id', new ParseIntPipe()) id: number,
   ): Promise<DeleteAnonymousProp> {
-    await this.chatService.deleteAnonymousPrefixName(id);
+    await this.anonymousService.deleteAnonymousPrefixName(id);
     return {
       statusCode: HttpStatus.OK,
       message: `${id} 번 데이터가 성공적으로 삭제되었습니다.`,
@@ -206,7 +208,7 @@ export default class ChatController implements IChatController {
     { user: { id: adminId } }: AuthRequest,
     @Body() { name }: AnonymousPropDto,
   ): Promise<GeneralResponse> {
-    await this.chatService.addAnonymousPrefixName(adminId, name);
+    await this.anonymousService.addAnonymousPrefixName(adminId, name);
     return {
       statusCode: HttpStatus.OK,
       message: '익명 사용자 이름 추가를 성공하였습니다.',
@@ -223,7 +225,7 @@ export default class ChatController implements IChatController {
     @Param('id', new ParseIntPipe()) id: number,
     @Body() { name }: AnonymousPropDto,
   ): Promise<UpdateAnonymousProp> {
-    await this.chatService.modifyAnonymousName(id, name);
+    await this.anonymousService.modifyAnonymousName(id, name);
     return {
       statusCode: HttpStatus.OK,
       message: `${id} 번 데이터를 ${name} 으로 성공적으로 변경하였습니다.`,
@@ -241,7 +243,7 @@ export default class ChatController implements IChatController {
   async deleteAnonymousNameRuleByAdmin(
     @Param('id', new ParseIntPipe()) id: number,
   ): Promise<DeleteAnonymousProp> {
-    await this.chatService.deleteAnonymousName(id);
+    await this.anonymousService.deleteAnonymousName(id);
     return {
       statusCode: HttpStatus.OK,
       message: `${id} 번 데이터가 성공적으로 삭제되었습니다.`,
@@ -257,7 +259,7 @@ export default class ChatController implements IChatController {
   @UseGuards(AdminGuard)
   @Get('/anonymous/prefix-name')
   async findAllAnonymousPrefixRuleByAdmin(): Promise<FindAllAnonymousProp> {
-    const list = await this.chatService.findAllAnonymousPrefix();
+    const list = await this.anonymousService.findAllAnonymousPrefix();
     return {
       statusCode: HttpStatus.OK,
       message: '익명 접두어 목록을 성공적으로 불러왔습니다.',
@@ -273,7 +275,7 @@ export default class ChatController implements IChatController {
   @UseGuards(AdminGuard)
   @Get('/anonymous/name')
   async findAllAnonymousNameRuleByAdmin(): Promise<FindAllAnonymousProp> {
-    const list = await this.chatService.findAllAnonymousName();
+    const list = await this.anonymousService.findAllAnonymousName();
     return {
       statusCode: HttpStatus.OK,
       message: '익명 이름 목록을 성공적으로 불러왔습니다.',

--- a/nest/src/models/chat/chat.gateway.ts
+++ b/nest/src/models/chat/chat.gateway.ts
@@ -8,13 +8,11 @@ import {
   MessageBody,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Logger, UnauthorizedException } from '@nestjs/common';
-
-import ChatService from './chat.service';
-import UserRepository from '@models/user/repositories/user.repository';
+import ChatService from './services/chat.service';
 import { IChatGateway } from '@models/chat/interface/gateway';
-import AnonymousRoomUserRepository from '@models/chat/repositories/anonymous-room-user.repository';
-import { ChatEvent } from '@common/helpers/enum.helper';
+import { ChatEvent } from './interface/enum';
+import ChatSimplifyService from '@models/chat/services/simple.service';
+import ChatDevelopmentService from '@models/chat/services/dev.service';
 
 @WebSocketGateway({
   namespace: 'chat',
@@ -24,12 +22,10 @@ export default class ChatGateway implements IChatGateway, OnGatewayConnection, O
   @WebSocketServer()
   server!: Server;
 
-  private logger = new Logger('Chat');
-
   constructor(
+    private readonly simplifyService: ChatSimplifyService,
     private readonly chatService: ChatService,
-    private readonly userRepository: UserRepository,
-    private readonly anonymousRoomUserRepository: AnonymousRoomUserRepository,
+    private readonly chatDevService: ChatDevelopmentService,
   ) {}
 
   /**
@@ -37,22 +33,15 @@ export default class ChatGateway implements IChatGateway, OnGatewayConnection, O
    * @desc 방이 존재하지 않으면 사용자 희망분야 기반으로 생성하고 입장처리합니다.
    */
   async handleConnection(@ConnectedSocket() client: Socket) {
-    const { auth } = client.handshake;
-    const { userId, roomId } = this.chatService.getInfoFromHeader(auth);
-    client.join(String(roomId));
-    const {
-      anonymousUser: { username },
-      isCreated,
-    } = await this.chatService.findOrCreateAnonymousName(auth);
-    const user = await this.userRepository.findOne({ id: userId });
-    if (!user) throw new UnauthorizedException();
-    if (isCreated) {
-      await this.chatService.joinRoom(user, Number(roomId));
-      this.chatService.emitEnterOrExitEvent(this.server, username, 'enter');
-    }
-    await this.chatService.emitMemberCountEvent(this.server, client.handshake.auth);
-    this.logger.debug(`client ${client.conn.id} connection!`);
-    this.logger.log(`${username} 유저가 ${roomId} 번 방에 참여되었습니다.`);
+    const authInfo = this.chatService.getInfoFromHeader(client.handshake.auth);
+
+    const isCreatedInfo = await this.simplifyService.simplifyConnectMethods(client, authInfo);
+    await this.simplifyService.simplifySocketConnectEvents(this.server, {
+      info: authInfo,
+      ...isCreatedInfo,
+    });
+
+    this.chatDevService.logHandleConnection(client, isCreatedInfo.username, authInfo.roomId);
   }
 
   /**
@@ -60,20 +49,12 @@ export default class ChatGateway implements IChatGateway, OnGatewayConnection, O
    * @desc 해당 방에서 인원 수가 0명이면 방을 삭제합니다.
    */
   async handleDisconnect(@ConnectedSocket() client: Socket) {
-    const { auth } = client.handshake;
-    const { userId, roomId } = this.chatService.getInfoFromHeader(auth);
-    await this.chatService.leaveRoom(auth);
-    client.leave(String(roomId));
-    const {
-      anonymousUser: { username },
-    } = await this.chatService.findOrCreateAnonymousName(auth);
-    await this.anonymousRoomUserRepository.deleteName(username);
-    this.chatService.emitEnterOrExitEvent(this.server, username, 'exit');
-    this.logger.log(`${username} 유저가 ${roomId} 방에서 퇴장하였습니다.`);
-    this.logger.debug(`client ${client.conn.id} disconnected`);
-    await this.chatService.checkDeleteRoom(auth);
-    await this.chatService.emitMemberCountEvent(this.server, auth);
-    this.server.to(String(roomId)).emit(ChatEvent.CHECK_MULTIPLE_USER, userId);
+    const authInfo = this.chatService.getInfoFromHeader(client.handshake.auth);
+
+    const anonymousName = await this.simplifyService.simplifyLeaveMethods(client, authInfo);
+    await this.simplifyService.simplifySocketLeaveEvents(this.server, authInfo, anonymousName);
+
+    this.chatDevService.logHandleDisconnection(client, anonymousName, authInfo.roomId);
   }
 
   /**

--- a/nest/src/models/chat/chat.module.ts
+++ b/nest/src/models/chat/chat.module.ts
@@ -3,11 +3,22 @@ import UserModule from '@models/user/user.module';
 import AuthModule from '@authentication/modules/auth.module';
 import ChatController from './chat.controller';
 import ChatGateway from './chat.gateway';
-import ChatService from './chat.service';
+import ChatService from './services/chat.service';
+import ChatAnonymousService from './services/anonymous.service';
+import ChatSimplifyService from '@models/chat/services/simple.service';
+import ChatDevelopmentService from '@models/chat/services/dev.service';
+import ChatEventService from '@models/chat/services/event.service';
 
 @Module({
   imports: [AuthModule, UserModule],
   controllers: [ChatController],
-  providers: [ChatGateway, ChatService],
+  providers: [
+    ChatService,
+    ChatGateway,
+    ChatAnonymousService,
+    ChatSimplifyService,
+    ChatEventService,
+    ChatDevelopmentService,
+  ],
 })
 export default class ChatModule {}

--- a/nest/src/models/chat/interface/enum.ts
+++ b/nest/src/models/chat/interface/enum.ts
@@ -1,0 +1,8 @@
+export enum ChatEvent {
+  ROOM_ENTER = 'enter',
+  ROOM_EXIT = 'exit',
+  CHECK_MULTIPLE_USER = 'check_multiple_user',
+  SEND_CHAT = 'chat',
+  SEND_MEMBER_COUNT = 'member_count',
+  WELCOME_MESSAGE = 'welcome_message',
+}

--- a/nest/src/models/chat/interface/service.ts
+++ b/nest/src/models/chat/interface/service.ts
@@ -1,9 +1,10 @@
 import { IncomingHttpHeaders } from 'http';
 import UserEntity from '@models/user/entities/user.entity';
 import RoomEntity from '@models/chat/entities/room.entity';
-import { Server } from 'socket.io';
+import { Server, Socket } from 'socket.io';
 import AnonymousPrefixEntity from '@models/chat/entities/anonymous_prefix.entity';
 import AnonymousNameEntity from '@models/chat/entities/anonymous_names.entity';
+import AnonymousRoomUserEntity from '@models/chat/entities/anonymous-room-user.entity';
 
 export interface LeaveRoom {
   username: string;
@@ -39,6 +40,22 @@ export interface InfoFromHeader {
   roomId: number;
 }
 
+export interface SimplifySocketConnect {
+  isCreated: boolean;
+  username: string;
+}
+
+export interface SimpleConnectEvent {
+  isCreated: boolean;
+  username: string;
+  info: InfoFromHeader;
+}
+
+export interface FindOrCreateAnonymousInfo {
+  anonymousUser: AnonymousRoomUserEntity;
+  isCreated: boolean;
+}
+
 export interface IChatService {
   getRecommendRoom(id: number): Promise<RoomEntity | FindRoomAndJoin>;
 
@@ -54,12 +71,24 @@ export interface IChatService {
 
   createChatResponse(chatId: number, ownerId: number, username: string, message: string): Chat;
 
-  emitMemberCountEvent(server: Server, auth: HandShakeAuth): Promise<void>;
-
-  emitEnterOrExitEvent(server: Server, username: string, type: 'enter' | 'exit'): void;
-
   getInfoFromHeader(auth: HandShakeAuth): InfoFromHeader;
+}
 
+export interface IChatSimpleService {
+  simplifyLeaveMethods(client: Socket, info: InfoFromHeader): Promise<string>;
+
+  simplifySocketLeaveEvents(
+    server: Server,
+    info: InfoFromHeader,
+    anonymousUserName: string,
+  ): Promise<void>;
+
+  simplifyConnectMethods(client: Socket, info: InfoFromHeader): Promise<SimplifySocketConnect>;
+
+  simplifySocketConnectEvents(server: Server, info: SimpleConnectEvent): Promise<void>;
+}
+
+export interface IChatAnonymousService {
   addAnonymousPrefixName(adminId: number, name: string): Promise<void>;
   modifyAnonymousPrefixName(id: number, name: string): Promise<void>;
   deleteAnonymousPrefixName(id: number): Promise<void>;
@@ -70,4 +99,18 @@ export interface IChatService {
 
   findAllAnonymousPrefix(): Promise<AnonymousPrefixEntity[] | null>;
   findAllAnonymousName(): Promise<AnonymousNameEntity[] | null>;
+
+  findOrCreateAnonymousName(auth: HandShakeAuth): Promise<FindOrCreateAnonymousInfo>;
+}
+
+export interface IChatEventService {
+  emitMemberCountEvent(server: Server, auth: HandShakeAuth): Promise<void>;
+
+  emitEnterOrExitEvent(server: Server, username: string, type: 'enter' | 'exit'): void;
+}
+
+export interface IChatDevelopmentService {
+  logHandleConnection(client: Socket, username: string, roomId: number): void;
+
+  logHandleDisconnection(client: Socket, username: string, roomId: number): void;
 }

--- a/nest/src/models/chat/services/anonymous.service.ts
+++ b/nest/src/models/chat/services/anonymous.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import UserRepository from '@src/models/user/repositories/user.repository';
+import { getRepository } from 'typeorm';
+import AnonymousNameEntity from '../entities/anonymous_names.entity';
+import AnonymousPrefixEntity from '../entities/anonymous_prefix.entity';
+import {
+  FindOrCreateAnonymousInfo,
+  HandShakeAuth,
+  IChatAnonymousService,
+} from '@models/chat/interface/service';
+import ChatService from '@models/chat/services/chat.service';
+import AnonymousRoomUserRepository from '@models/chat/repositories/anonymous-room-user.repository';
+
+/**
+ * @desc 익명 이름에 관한 서비스
+ */
+@Injectable()
+export default class ChatAnonymousService implements IChatAnonymousService {
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly userRepository: UserRepository,
+    private readonly anonymousRoomUserRepository: AnonymousRoomUserRepository,
+  ) {}
+
+  async addAnonymousPrefixName(adminId: number, name: string): Promise<void> {
+    const admin = await this.userRepository.findOne({ id: adminId });
+    await getRepository(AnonymousPrefixEntity)
+      .create({
+        name,
+        user: admin,
+      })
+      .save();
+  }
+
+  async modifyAnonymousPrefixName(id: number, name: string): Promise<void> {
+    await getRepository(AnonymousPrefixEntity).update(
+      { id },
+      {
+        name,
+      },
+    );
+  }
+
+  async deleteAnonymousPrefixName(id: number): Promise<void> {
+    await getRepository(AnonymousPrefixEntity).delete({ id });
+  }
+
+  /**
+   * @desc 익명 사용자 이름을 추가합니다.
+   */
+  async addAnonymousName(adminId: number, name: string): Promise<void> {
+    const admin = await this.userRepository.findOne({ id: adminId });
+    await getRepository(AnonymousNameEntity)
+      .create({
+        name,
+        user: admin,
+      })
+      .save();
+  }
+
+  async modifyAnonymousName(id: number, name: string): Promise<void> {
+    await getRepository(AnonymousNameEntity).update({ id }, { name });
+  }
+
+  async deleteAnonymousName(id: number): Promise<void> {
+    await getRepository(AnonymousNameEntity).delete({ id });
+  }
+
+  async findAllAnonymousName(): Promise<AnonymousNameEntity[] | null> {
+    const list = await getRepository(AnonymousNameEntity).find();
+    if (!list) return null;
+    return list;
+  }
+
+  async findAllAnonymousPrefix(): Promise<AnonymousPrefixEntity[] | null> {
+    const list = await getRepository(AnonymousPrefixEntity).find();
+    if (!list) return null;
+    return list;
+  }
+
+  /**
+   * @desc 익명 이름을 생성하여 반환합니다.
+   */
+  async findOrCreateAnonymousName(auth: HandShakeAuth): Promise<FindOrCreateAnonymousInfo> {
+    const { userId, roomId } = this.chatService.getInfoFromHeader(auth);
+    return this.anonymousRoomUserRepository.findOrCreate(userId, roomId);
+  }
+}

--- a/nest/src/models/chat/services/dev.service.ts
+++ b/nest/src/models/chat/services/dev.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { IChatDevelopmentService } from '@models/chat/interface/service';
+import { Socket } from 'socket.io';
+
+@Injectable()
+export default class ChatDevelopmentService implements IChatDevelopmentService {
+  private readonly chatDevLog = new Logger('ChatDevService');
+
+  logHandleConnection(client: Socket, username: string, roomId: number): void {
+    this.chatDevLog.debug(`client ${client.conn.id} connection!`);
+    this.chatDevLog.log(`${username} 유저가 ${roomId} 번 방에 참여되었습니다.`);
+  }
+
+  logHandleDisconnection(client: Socket, username: string, roomId: number): void {
+    this.chatDevLog.log(`${username} 유저가 ${roomId} 방에서 퇴장하였습니다.`);
+    this.chatDevLog.debug(`client ${client.conn.id} disconnected`);
+  }
+}

--- a/nest/src/models/chat/services/event.service.ts
+++ b/nest/src/models/chat/services/event.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { HandShakeAuth, IChatEventService } from '@models/chat/interface/service';
+import { Server } from 'socket.io';
+import { ChatEvent } from '@models/chat/interface/enum';
+import { v1 as uuid } from 'uuid';
+import ChatService from '@models/chat/services/chat.service';
+import RoomUserRepository from '@models/chat/repositories/room-user.repository';
+
+@Injectable()
+export default class ChatEventService implements IChatEventService {
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly roomUserRepository: RoomUserRepository,
+  ) {}
+
+  /**
+   * @desc 채팅방의 멤버수를 구해서 멤버수 카운트 이벤트를 emit 합니다.
+   */
+  async emitMemberCountEvent(server: Server, auth: HandShakeAuth): Promise<void> {
+    const { roomId } = this.chatService.getInfoFromHeader(auth);
+    const memberCount = await this.roomUserRepository.count({
+      where: { roomId },
+    });
+    server.emit(ChatEvent.SEND_MEMBER_COUNT, memberCount);
+  }
+
+  /**
+   * @desc 입장 또는 퇴장 이벤트를 emit 합니다.
+   */
+  emitEnterOrExitEvent(server: Server, username: string, type: 'enter' | 'exit'): void {
+    server.emit(type, {
+      id: uuid(),
+      type,
+      username,
+    });
+  }
+}

--- a/nest/src/models/chat/services/simple.service.ts
+++ b/nest/src/models/chat/services/simple.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  IChatSimpleService,
+  InfoFromHeader,
+  SimpleConnectEvent,
+  SimplifySocketConnect,
+} from '@models/chat/interface/service';
+import { Server, Socket } from 'socket.io';
+import ChatService from '@models/chat/services/chat.service';
+import { ChatEvent } from '@models/chat/interface/enum';
+import AnonymousRoomUserRepository from '@models/chat/repositories/anonymous-room-user.repository';
+import UserRepository from '@models/user/repositories/user.repository';
+import ChatEventService from '@models/chat/services/event.service';
+import ChatAnonymousService from '@models/chat/services/anonymous.service';
+
+@Injectable()
+export default class ChatSimplifyService implements IChatSimpleService {
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly anonymousService: ChatAnonymousService,
+    private readonly chatEventService: ChatEventService,
+    private readonly anonymousRoomUserRepository: AnonymousRoomUserRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  /**
+   * @desc 소켓 서버에서 유저 퇴장 시 발생하는 이벤트 로직 메서드
+   */
+  async simplifySocketLeaveEvents(
+    server: Server,
+    info: InfoFromHeader,
+    anonymousUserName: string,
+  ): Promise<void> {
+    this.chatEventService.emitEnterOrExitEvent(server, anonymousUserName, 'exit');
+    await this.chatEventService.emitMemberCountEvent(server, info);
+    server.to(String(info.roomId)).emit(ChatEvent.CHECK_MULTIPLE_USER, info.userId);
+  }
+
+  /**
+   * @desc 서버 소켓과 데이터베이스에서 유저를 퇴장처리하는 로직이 간소화 된 메서드
+   */
+  async simplifyLeaveMethods(client: Socket, info: InfoFromHeader): Promise<string> {
+    await this.chatService.leaveRoom(info);
+    client.leave(String(info.roomId));
+
+    const {
+      anonymousUser: { username },
+    } = await this.anonymousService.findOrCreateAnonymousName(info);
+    await this.anonymousRoomUserRepository.deleteName(username);
+    await this.chatService.checkDeleteRoom(info);
+    return username;
+  }
+
+  /**
+   * @desc 소켓 서버에서 유저 입장 시 발생하는 이벤트 로직 메서드
+   */
+  async simplifySocketConnectEvents(
+    server: Server,
+    { info: authInfo, username, isCreated }: SimpleConnectEvent,
+  ): Promise<void> {
+    if (isCreated) this.chatEventService.emitEnterOrExitEvent(server, username, 'enter');
+    await this.chatEventService.emitMemberCountEvent(server, authInfo);
+  }
+
+  /**
+   * @desc 서버 소켓과 데이터베이스에서 유저를 입장처리하는 로직이 간소화 된 메서드
+   */
+  async simplifyConnectMethods(
+    client: Socket,
+    info: InfoFromHeader,
+  ): Promise<SimplifySocketConnect> {
+    const { userId, roomId } = info;
+    client.join(String(roomId));
+    const {
+      anonymousUser: { username },
+      isCreated,
+    } = await this.anonymousService.findOrCreateAnonymousName(info);
+    const user = await this.userRepository.findOne({ id: userId });
+    if (!user) throw new UnauthorizedException();
+    if (isCreated) await this.chatService.joinRoom(user, roomId);
+
+    return {
+      isCreated,
+      username,
+    };
+  }
+}


### PR DESCRIPTION
# 현재 PR은 작성 중입니다.

# Summary
* ChatService, ChatGateWay, ChatController 3 가지 계층에서 진행 중인 로직을 서비스 중심으로 역할, 책임을 분할하여 재디자인 하였습니다.
* ChatService 에서 채팅과 관련된 모든 로직을 담당하고 있던 기존 방식에서 이벤트, 채팅방, 채팅, 개발용도, 익명, 추상화 로 분류하여 기능을 나누고 서로 간에 참조 협력 관계를 개선하였습니다.

# Before
![image](https://user-images.githubusercontent.com/50310464/136040307-157d0147-f489-41e9-bc2e-68803a7f444a.png)
* 전체적인 도메인 구조에서 Service 에서 어떠한 로직을 처리하는 지 과하게 일반화하여 해석하게 됨, 결과적으로 유지보수성이 급격히 수직낙하된다.

# After
![image](https://user-images.githubusercontent.com/50310464/136040508-3fc8c424-dd6f-4122-a82e-378dc0a9bb6e.png)
* 각 서비스마다 하나의 책임을 이루어 시스템을 안정성있게 이루게 된다.