### PR TITLE
feat: 유저 타입에 events 추가

### DIFF
--- a/next/src/components/common/Calendar/index.tsx
+++ b/next/src/components/common/Calendar/index.tsx
@@ -4,9 +4,11 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 import moment from 'moment';
 import 'moment/locale/ko';
 
-import { Event, EventAgenda } from './parts';
-import events from './tempEvents';
-import type { CustomEvent } from './tempEvents';
+import useUser from '@hooks/useUser';
+import type { UserEvent } from 'typings/auth';
+
+import * as parts from './parts';
+import tempEvents from './tempEvents';
 
 type Props = {
   wrapperStyle?: React.CSSProperties;
@@ -15,22 +17,27 @@ type Props = {
 const allViews = Object.values(Views);
 const localizer = momentLocalizer(moment);
 
-const MyCalendar = ({ wrapperStyle }: Props) => (
-  <div style={wrapperStyle}>
-    <Calendar<CustomEvent>
-      views={allViews}
-      events={events}
-      localizer={localizer}
-      defaultDate={new Date()}
-      defaultView={Views.AGENDA}
-      components={{
-        event: Event,
-        agenda: {
-          event: EventAgenda,
-        },
-      }}
-    />
-  </div>
-);
+const MyCalendar = ({ wrapperStyle }: Props) => {
+  const { user } = useUser();
+
+  return (
+    <section style={wrapperStyle}>
+      <Calendar<UserEvent>
+        views={allViews}
+        // events={user?.events || []}
+        events={tempEvents}
+        localizer={localizer}
+        defaultDate={new Date()}
+        defaultView={Views.AGENDA}
+        components={{
+          event: parts.Event,
+          agenda: {
+            event: parts.EventAgenda,
+          },
+        }}
+      />
+    </section>
+  );
+};
 
 export default MyCalendar;

--- a/next/src/components/common/Calendar/parts.tsx
+++ b/next/src/components/common/Calendar/parts.tsx
@@ -1,15 +1,15 @@
 import { theme } from '@globalStyles/theme';
 import type { EventProps } from 'react-big-calendar';
-import type { CustomEvent } from './tempEvents';
+import type { UserEvent } from 'typings/auth';
 
-export const Event = ({ event }: EventProps<CustomEvent>) => (
+export const Event = ({ event }: EventProps<UserEvent>) => (
   <span>
     <b>{event.title}</b>
     {event.desc && `:  ${event.desc}`}
   </span>
 );
 
-export const EventAgenda = ({ event }: EventProps<CustomEvent>) => (
+export const EventAgenda = ({ event }: EventProps<UserEvent>) => (
   <span>
     <b style={{ color: theme.color['blue-1'] }}>{event.title}</b>
     {event.desc && <p style={{ color: theme.color['gray-5'] }}>{event.desc}</p>}

--- a/next/src/components/common/Calendar/tempEvents.ts
+++ b/next/src/components/common/Calendar/tempEvents.ts
@@ -1,13 +1,8 @@
-import type { Event } from 'react-big-calendar';
-
-export interface CustomEvent extends Event {
-  id: number;
-  desc?: string;
-}
+import type { UserEvent } from 'typings/auth';
 
 const now = new Date();
 
-const tempEvents: CustomEvent[] = [
+const tempEvents: UserEvent[] = [
   {
     id: 0,
     title: 'All Day Event very long title',

--- a/next/typings/auth.ts
+++ b/next/typings/auth.ts
@@ -1,3 +1,4 @@
+import type { Event } from 'react-big-calendar';
 import type { IGeneralServerResponse } from './common';
 
 /**
@@ -47,6 +48,14 @@ export interface IAuthSuccessResponse extends IGeneralServerResponse {
 }
 
 /**
+ * 캘린더에 반영되는 유저 일정
+ */
+export interface UserEvent extends Event {
+  id: number;
+  desc?: string;
+}
+
+/**
  * 유저가 가지고 있는 정보
  */
 export interface IUserInfo {
@@ -55,6 +64,7 @@ export interface IUserInfo {
   email: string;
   skills: IOptionalProps[] | null;
   job: IOptionalProps | null;
+  events: UserEvent[];
 }
 
 /**


### PR DESCRIPTION
# Summary
``` ts
// next/typings/auth.ts
import type { Event } from 'react-big-calendar';

/**
 * 캘린더에 반영되는 유저 일정
 */
export interface UserEvent extends Event {
  id: number;
  desc?: string;
}

/**
 * 유저가 가지고 있는 정보
 */
export interface IUserInfo {
  id: number;
  username: string;
  email: string;
  skills: IOptionalProps[] | null;
  job: IOptionalProps | null;
  events: UserEvent[]; // added
}
```
* 기존 IUserInfo 타입에 events가 추가되었습니다.
* next mock api 임시 새로운 필드인 events가 포함된 user정보를 만들어 관련 기능 미리 개발하겠습니다.